### PR TITLE
feat: add recipient to swap for caller

### DIFF
--- a/contracts/DCAHubCompanion/DCAHubCompanionSwapHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionSwapHandler.sol
@@ -24,13 +24,14 @@ abstract contract DCAHubCompanionSwapHandler is DeadlineValidation, DCAHubCompan
     IDCAHub.PairIndexes[] calldata _pairsToSwap,
     uint256[] calldata _minimumOutput,
     uint256[] calldata _maximumInput,
+    address _recipient,
     uint256 _deadline
   ) external payable checkDeadline(_deadline) returns (IDCAHub.SwapInfo memory _swapInfo) {
     uint256[] memory _borrow = new uint256[](_tokens.length);
     _swapInfo = hub.swap(
       _tokens,
       _pairsToSwap,
-      msg.sender,
+      _recipient,
       address(this),
       _borrow,
       abi.encode(SwapData({plan: SwapPlan.SWAP_FOR_CALLER, data: abi.encode(msg.sender, msg.value)}))

--- a/contracts/interfaces/IDCAHubCompanion.sol
+++ b/contracts/interfaces/IDCAHubCompanion.sol
@@ -43,6 +43,7 @@ interface IDCAHubCompanionSwapHandler is IDCAHubSwapCallee {
   /// @param _pairsToSwap The pairs to swap
   /// @param _minimumOutput The minimum amount of tokens to receive as part of the swap
   /// @param _maximumInput The maximum amount of tokens to provide as part of the swap
+  /// @param _recipient Address that will recieve all the tokens from the swap
   /// @param _deadline Deadline when the swap becomes invalid
   /// @return The information about the executed swap
   function swapForCaller(
@@ -50,6 +51,7 @@ interface IDCAHubCompanionSwapHandler is IDCAHubSwapCallee {
     IDCAHub.PairIndexes[] calldata _pairsToSwap,
     uint256[] calldata _minimumOutput,
     uint256[] calldata _maximumInput,
+    address _recipient,
     uint256 _deadline
   ) external payable returns (IDCAHub.SwapInfo memory);
 }

--- a/test/unit/libraries/modify-position-with-rate.spec.ts
+++ b/test/unit/libraries/modify-position-with-rate.spec.ts
@@ -9,7 +9,7 @@ import constants from '@test-utils/constants';
 
 chai.use(smock.matchers);
 
-contract.only('ModifyPositionWithRate', () => {
+contract('ModifyPositionWithRate', () => {
   const POSITION_ID = 1;
   const ORIGINAL_RATE = 100000;
   const SWAPS_LEFT = 10;


### PR DESCRIPTION
We are now adding a recipient to `swapForCaller`, so that the user can control where the funds go to