### PR TITLE
feat: add multicall handler

### DIFF
--- a/contracts/DCAHubCompanion/DCAHubCompanion.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanion.sol
@@ -6,6 +6,7 @@ import './DCAHubCompanionSwapHandler.sol';
 import './DCAHubCompanionWTokenPositionHandler.sol';
 import './DCAHubCompanionDustHandler.sol';
 import './DCAHubCompanionLibrariesHandler.sol';
+import './DCAHubCompanionMulticallHandler.sol';
 
 contract DCAHubCompanion is
   DCAHubCompanionParameters,
@@ -13,6 +14,7 @@ contract DCAHubCompanion is
   DCAHubCompanionWTokenPositionHandler,
   DCAHubCompanionDustHandler,
   DCAHubCompanionLibrariesHandler,
+  DCAHubCompanionMulticallHandler,
   IDCAHubCompanion
 {
   constructor(

--- a/contracts/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import './DCAHubCompanionParameters.sol';
+
+abstract contract DCAHubCompanionMulticallHandler is DCAHubCompanionParameters, IDCAHubCompanionMulticallHandler {
+  using SafeERC20 for IERC20Metadata;
+
+  function withdrawSwappedProxy(uint256 _positionId, address _recipient) external returns (uint256 _swapped) {
+    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
+      revert IDCAHubCompanion.UnauthorizedCaller();
+    _swapped = hub.withdrawSwapped(_positionId, _recipient);
+  }
+
+  function withdrawSwappedManyProxy(IDCAHub.PositionSet[] calldata _positions, address _recipient)
+    external
+    returns (uint256[] memory _withdrawn)
+  {
+    for (uint256 i; i < _positions.length; i++) {
+      for (uint256 j; j < _positions[i].positionIds.length; j++) {
+        if (!permissionManager.hasPermission(_positions[i].positionIds[j], msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
+          revert IDCAHubCompanion.UnauthorizedCaller();
+      }
+    }
+    _withdrawn = hub.withdrawSwappedMany(_positions, _recipient);
+  }
+
+  function increasePositionProxy(
+    uint256 _positionId,
+    uint256 _amount,
+    uint32 _newSwaps
+  ) external {
+    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.INCREASE))
+      revert IDCAHubCompanion.UnauthorizedCaller();
+    IERC20Metadata _from = hub.userPosition(_positionId).from;
+    _from.safeTransferFrom(msg.sender, address(this), _amount);
+    _from.approve(address(hub), _amount);
+    hub.increasePosition(_positionId, _amount, _newSwaps);
+  }
+
+  function reducePositionProxy(
+    uint256 _positionId,
+    uint256 _amount,
+    uint32 _newSwaps,
+    address _recipient
+  ) external {
+    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.REDUCE))
+      revert IDCAHubCompanion.UnauthorizedCaller();
+    hub.reducePosition(_positionId, _amount, _newSwaps, _recipient);
+  }
+
+  function terminateProxy(
+    uint256 _positionId,
+    address _recipientUnswapped,
+    address _recipientSwapped
+  ) external returns (uint256 _unswapped, uint256 _swapped) {
+    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE))
+      revert IDCAHubCompanion.UnauthorizedCaller();
+    (_unswapped, _swapped) = hub.terminate(_positionId, _recipientUnswapped, _recipientSwapped);
+  }
+}

--- a/contracts/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
@@ -1,15 +1,46 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import '@openzeppelin/contracts/utils/Multicall.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import './DCAHubCompanionParameters.sol';
 
-abstract contract DCAHubCompanionMulticallHandler is DCAHubCompanionParameters, IDCAHubCompanionMulticallHandler {
+abstract contract DCAHubCompanionMulticallHandler is Multicall, DCAHubCompanionParameters, IDCAHubCompanionMulticallHandler {
   using SafeERC20 for IERC20Metadata;
 
-  function withdrawSwappedProxy(uint256 _positionId, address _recipient) external returns (uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  function permissionPermitProxy(
+    IDCAPermissionManager.PermissionSet[] calldata _permissions,
+    uint256 _tokenId,
+    uint256 _deadline,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  ) external {
+    permissionManager.permissionPermit(_permissions, _tokenId, _deadline, _v, _r, _s);
+  }
+
+  function depositProxy(
+    address _from,
+    address _to,
+    uint256 _amount,
+    uint32 _amountOfSwaps,
+    uint32 _swapInterval,
+    address _owner,
+    IDCAPermissionManager.PermissionSet[] calldata _permissions,
+    bool _transferFromCaller
+  ) external returns (uint256 _positionId) {
+    if (_transferFromCaller) {
+      IERC20Metadata(_from).safeTransferFrom(msg.sender, address(this), _amount);
+    }
+    _approveHub(_from, _amount);
+    _positionId = hub.deposit(_from, _to, _amount, _amountOfSwaps, _swapInterval, _owner, _permissions);
+  }
+
+  function withdrawSwappedProxy(uint256 _positionId, address _recipient)
+    external
+    checkPermission(_positionId, IDCAPermissionManager.Permission.WITHDRAW)
+    returns (uint256 _swapped)
+  {
     _swapped = hub.withdrawSwapped(_positionId, _recipient);
   }
 
@@ -19,8 +50,7 @@ abstract contract DCAHubCompanionMulticallHandler is DCAHubCompanionParameters, 
   {
     for (uint256 i; i < _positions.length; i++) {
       for (uint256 j; j < _positions[i].positionIds.length; j++) {
-        if (!permissionManager.hasPermission(_positions[i].positionIds[j], msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
-          revert IDCAHubCompanion.UnauthorizedCaller();
+        _checkPermissionOrFail(_positions[i].positionIds[j], IDCAPermissionManager.Permission.WITHDRAW);
       }
     }
     _withdrawn = hub.withdrawSwappedMany(_positions, _recipient);
@@ -29,13 +59,14 @@ abstract contract DCAHubCompanionMulticallHandler is DCAHubCompanionParameters, 
   function increasePositionProxy(
     uint256 _positionId,
     uint256 _amount,
-    uint32 _newSwaps
-  ) external {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.INCREASE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+    uint32 _newSwaps,
+    bool _transferFromCaller
+  ) external checkPermission(_positionId, IDCAPermissionManager.Permission.INCREASE) {
     IERC20Metadata _from = hub.userPosition(_positionId).from;
-    _from.safeTransferFrom(msg.sender, address(this), _amount);
-    _from.approve(address(hub), _amount);
+    if (_transferFromCaller) {
+      _from.safeTransferFrom(msg.sender, address(this), _amount);
+    }
+    _approveHub(address(_from), _amount);
     hub.increasePosition(_positionId, _amount, _newSwaps);
   }
 
@@ -44,9 +75,7 @@ abstract contract DCAHubCompanionMulticallHandler is DCAHubCompanionParameters, 
     uint256 _amount,
     uint32 _newSwaps,
     address _recipient
-  ) external {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.REDUCE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external checkPermission(_positionId, IDCAPermissionManager.Permission.REDUCE) {
     hub.reducePosition(_positionId, _amount, _newSwaps, _recipient);
   }
 
@@ -54,9 +83,7 @@ abstract contract DCAHubCompanionMulticallHandler is DCAHubCompanionParameters, 
     uint256 _positionId,
     address _recipientUnswapped,
     address _recipientSwapped
-  ) external returns (uint256 _unswapped, uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external checkPermission(_positionId, IDCAPermissionManager.Permission.TERMINATE) returns (uint256 _unswapped, uint256 _swapped) {
     (_unswapped, _swapped) = hub.terminate(_positionId, _recipientUnswapped, _recipientSwapped);
   }
 }

--- a/contracts/DCAHubCompanion/DCAHubCompanionParameters.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionParameters.sol
@@ -9,6 +9,7 @@ abstract contract DCAHubCompanionParameters is Governable, IDCAHubCompanionParam
   IDCAPermissionManager public immutable permissionManager;
   IWrappedProtocolToken public immutable wToken;
   address public constant PROTOCOL_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+  mapping(address => bool) public tokenHasApprovalIssue;
 
   constructor(
     IDCAHub _hub,
@@ -21,5 +22,28 @@ abstract contract DCAHubCompanionParameters is Governable, IDCAHubCompanionParam
     hub = _hub;
     wToken = _wToken;
     permissionManager = _permissionManager;
+  }
+
+  function setTokensWithApprovalIssues(address[] calldata _addresses, bool[] calldata _hasIssue) external onlyGovernor {
+    if (_addresses.length != _hasIssue.length) revert InvalidTokenApprovalParams();
+    for (uint256 i; i < _addresses.length; i++) {
+      tokenHasApprovalIssue[_addresses[i]] = _hasIssue[i];
+    }
+    emit TokenWithApprovalIssuesSet(_addresses, _hasIssue);
+  }
+
+  function _checkPermissionOrFail(uint256 _positionId, IDCAPermissionManager.Permission _permission) internal view {
+    if (!permissionManager.hasPermission(_positionId, msg.sender, _permission)) revert IDCAHubCompanion.UnauthorizedCaller();
+  }
+
+  function _approveHub(address _from, uint256 _amount) internal {
+    // If the token we are going to approve doesn't have the approval issue we see in USDT, we will approve 1 extra.
+    // We are doing that so that the allowance isn't fully spent, and the next approve is cheaper.
+    IERC20(_from).approve(address(hub), tokenHasApprovalIssue[_from] ? _amount : _amount + 1);
+  }
+
+  modifier checkPermission(uint256 _positionId, IDCAPermissionManager.Permission _permission) {
+    _checkPermissionOrFail(_positionId, _permission);
+    _;
   }
 }

--- a/contracts/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
@@ -30,7 +30,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
       _convertedFrom = address(wToken);
     } else {
       IERC20(_from).safeTransferFrom(msg.sender, address(this), _amount);
-      IERC20(_from).approve(address(hub), _amount);
+      _approveHub(_from, _amount);
       _convertedTo = address(wToken);
     }
 
@@ -48,9 +48,11 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     emit ConvertedDeposit(_positionId, _from, _convertedFrom, _to, _convertedTo);
   }
 
-  function withdrawSwappedUsingProtocolToken(uint256 _positionId, address payable _recipient) external returns (uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  function withdrawSwappedUsingProtocolToken(uint256 _positionId, address payable _recipient)
+    external
+    checkPermission(_positionId, IDCAPermissionManager.Permission.WITHDRAW)
+    returns (uint256 _swapped)
+  {
     _swapped = hub.withdrawSwapped(_positionId, address(this));
     _unwrapAndSend(_swapped, _recipient);
   }
@@ -60,8 +62,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     returns (uint256 _swapped)
   {
     for (uint256 i; i < _positionIds.length; i++) {
-      if (!permissionManager.hasPermission(_positionIds[i], msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
-        revert IDCAHubCompanion.UnauthorizedCaller();
+      _checkPermissionOrFail(_positionIds[i], IDCAPermissionManager.Permission.WITHDRAW);
     }
     IDCAHub.PositionSet[] memory _positionSets = new IDCAHub.PositionSet[](1);
     _positionSets[0].token = address(wToken);
@@ -75,9 +76,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint256 _positionId,
     uint256 _amount,
     uint32 _newSwaps
-  ) external payable {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.INCREASE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external payable checkPermission(_positionId, IDCAPermissionManager.Permission.INCREASE) {
     _wrap(_amount);
     hub.increasePosition(_positionId, _amount, _newSwaps);
   }
@@ -87,9 +86,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint256 _amount,
     uint32 _newSwaps,
     address payable _recipient
-  ) external {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.REDUCE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external checkPermission(_positionId, IDCAPermissionManager.Permission.REDUCE) {
     hub.reducePosition(_positionId, _amount, _newSwaps, address(this));
     _unwrapAndSend(_amount, _recipient);
   }
@@ -98,9 +95,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint256 _positionId,
     address payable _recipientUnswapped,
     address _recipientSwapped
-  ) external returns (uint256 _unswapped, uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external checkPermission(_positionId, IDCAPermissionManager.Permission.TERMINATE) returns (uint256 _unswapped, uint256 _swapped) {
     (_unswapped, _swapped) = hub.terminate(_positionId, address(this), _recipientSwapped);
     _unwrapAndSend(_unswapped, _recipientUnswapped);
   }
@@ -109,9 +104,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint256 _positionId,
     address _recipientUnswapped,
     address payable _recipientSwapped
-  ) external returns (uint256 _unswapped, uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external checkPermission(_positionId, IDCAPermissionManager.Permission.TERMINATE) returns (uint256 _unswapped, uint256 _swapped) {
     (_unswapped, _swapped) = hub.terminate(_positionId, _recipientUnswapped, address(this));
     _unwrapAndSend(_swapped, _recipientSwapped);
   }

--- a/contracts/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
@@ -49,7 +49,8 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
   }
 
   function withdrawSwappedUsingProtocolToken(uint256 _positionId, address payable _recipient) external returns (uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.WITHDRAW)) revert UnauthorizedCaller();
+    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
+      revert IDCAHubCompanion.UnauthorizedCaller();
     _swapped = hub.withdrawSwapped(_positionId, address(this));
     _unwrapAndSend(_swapped, _recipient);
   }
@@ -59,7 +60,8 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     returns (uint256 _swapped)
   {
     for (uint256 i; i < _positionIds.length; i++) {
-      if (!permissionManager.hasPermission(_positionIds[i], msg.sender, IDCAPermissionManager.Permission.WITHDRAW)) revert UnauthorizedCaller();
+      if (!permissionManager.hasPermission(_positionIds[i], msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
+        revert IDCAHubCompanion.UnauthorizedCaller();
     }
     IDCAHub.PositionSet[] memory _positionSets = new IDCAHub.PositionSet[](1);
     _positionSets[0].token = address(wToken);
@@ -74,7 +76,8 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint256 _amount,
     uint32 _newSwaps
   ) external payable {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.INCREASE)) revert UnauthorizedCaller();
+    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.INCREASE))
+      revert IDCAHubCompanion.UnauthorizedCaller();
     _wrap(_amount);
     hub.increasePosition(_positionId, _amount, _newSwaps);
   }
@@ -85,7 +88,8 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint32 _newSwaps,
     address payable _recipient
   ) external {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.REDUCE)) revert UnauthorizedCaller();
+    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.REDUCE))
+      revert IDCAHubCompanion.UnauthorizedCaller();
     hub.reducePosition(_positionId, _amount, _newSwaps, address(this));
     _unwrapAndSend(_amount, _recipient);
   }
@@ -95,7 +99,8 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     address payable _recipientUnswapped,
     address _recipientSwapped
   ) external returns (uint256 _unswapped, uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE)) revert UnauthorizedCaller();
+    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE))
+      revert IDCAHubCompanion.UnauthorizedCaller();
     (_unswapped, _swapped) = hub.terminate(_positionId, address(this), _recipientSwapped);
     _unwrapAndSend(_unswapped, _recipientUnswapped);
   }
@@ -105,7 +110,8 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     address _recipientUnswapped,
     address payable _recipientSwapped
   ) external returns (uint256 _unswapped, uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE)) revert UnauthorizedCaller();
+    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE))
+      revert IDCAHubCompanion.UnauthorizedCaller();
     (_unswapped, _swapped) = hub.terminate(_positionId, _recipientUnswapped, address(this));
     _unwrapAndSend(_swapped, _recipientSwapped);
   }

--- a/contracts/interfaces/IDCAHubCompanion.sol
+++ b/contracts/interfaces/IDCAHubCompanion.sol
@@ -10,6 +10,14 @@ import './utils/IGovernable.sol';
 import './ISharedTypes.sol';
 
 interface IDCAHubCompanionParameters is IGovernable {
+  /// @notice Thrown when the given parameters are invalid
+  error InvalidTokenApprovalParams();
+
+  /// @notice Emitted when tokens with approval issues are set
+  /// @param addresses The addresses of the tokens
+  /// @param hasIssue Whether they have issues or not
+  event TokenWithApprovalIssuesSet(address[] addresses, bool[] hasIssue);
+
   /// @notice Returns the DCA Hub's address
   /// @dev This value cannot be modified
   /// @return The DCA Hub contract
@@ -29,6 +37,17 @@ interface IDCAHubCompanionParameters is IGovernable {
   /// @notice Returns the permission manager contract
   /// @return The contract itself
   function permissionManager() external view returns (IDCAPermissionManager);
+
+  /// @notice Returns whether the given address has issues with approvals, like USDT
+  /// @param _tokenAddress The address of the token to check
+  /// @return Whether it has issues or not
+  function tokenHasApprovalIssue(address _tokenAddress) external view returns (bool);
+
+  /// @notice Sets whether specific addresses have issues with approvals, like USDT
+  /// @dev Will revert with `InvalidTokenApprovalParams` if the length of the given arrays differ
+  /// @param _addresses The addresses of the tokens
+  /// @param _hasIssue Wether they have issues or not
+  function setTokensWithApprovalIssues(address[] calldata _addresses, bool[] calldata _hasIssue) external;
 }
 
 interface IDCAHubCompanionSwapHandler is IDCAHubSwapCallee {
@@ -240,6 +259,27 @@ interface IDCAHubCompanionLibrariesHandler {
 }
 
 interface IDCAHubCompanionMulticallHandler {
+  /// @notice Creates a new position
+  /// @dev Meant to be used as part of a multicall
+  /// @param _from The address of the "from" token
+  /// @param _to The address of the "to" token
+  /// @param _amount How many "from" tokens will be swapped in total
+  /// @param _amountOfSwaps How many swaps to execute for this position
+  /// @param _swapInterval How frequently the position's swaps should be executed
+  /// @param _owner The address of the owner of the position being created
+  /// @param _transferFromCaller Determines if the funds should be transfered from the caller
+  /// @return _positionId The id of the created position
+  function depositProxy(
+    address _from,
+    address _to,
+    uint256 _amount,
+    uint32 _amountOfSwaps,
+    uint32 _swapInterval,
+    address _owner,
+    IDCAPermissionManager.PermissionSet[] calldata _permissions,
+    bool _transferFromCaller
+  ) external returns (uint256 _positionId);
+
   /// @notice Call the hub and withdraws all swapped tokens from a position to a recipient
   /// @dev Meant to be used as part of a multicall
   /// @param _positionId The position's id
@@ -262,10 +302,12 @@ interface IDCAHubCompanionMulticallHandler {
   /// @param _positionId The position's id
   /// @param _amount Amount of funds to add to the position
   /// @param _newSwaps The new amount of swaps
+  /// @param _transferFromCaller Determines if the funds should be transfered from the caller
   function increasePositionProxy(
     uint256 _positionId,
     uint256 _amount,
-    uint32 _newSwaps
+    uint32 _newSwaps,
+    bool _transferFromCaller
   ) external;
 
   /// @notice Call the hub and withdraws the specified amount from the unswapped balance and modifies the position so that
@@ -294,6 +336,22 @@ interface IDCAHubCompanionMulticallHandler {
     address _recipientUnswapped,
     address _recipientSwapped
   ) external returns (uint256 _unswapped, uint256 _swapped);
+
+  /// @notice Calls the permission manager and sets permissions via signature
+  /// @param _permissions The permissions to set
+  /// @param _tokenId The token's id
+  /// @param _deadline The deadline timestamp by which the call must be mined for the approve to work
+  /// @param _v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+  /// @param _r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+  /// @param _s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+  function permissionPermitProxy(
+    IDCAPermissionManager.PermissionSet[] calldata _permissions,
+    uint256 _tokenId,
+    uint256 _deadline,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  ) external;
 }
 
 interface IDCAHubCompanion is
@@ -301,7 +359,8 @@ interface IDCAHubCompanion is
   IDCAHubCompanionSwapHandler,
   IDCAHubCompanionWTokenPositionHandler,
   IDCAHubCompanionDustHandler,
-  IDCAHubCompanionLibrariesHandler
+  IDCAHubCompanionLibrariesHandler,
+  IDCAHubCompanionMulticallHandler
 {
   /// @notice Thrown when one of the parameters is a zero address
   error ZeroAddress();

--- a/contracts/mocks/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
+++ b/contracts/mocks/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../../DCAHubCompanion/DCAHubCompanionMulticallHandler.sol';
+import './DCAHubCompanionParameters.sol';
+
+contract DCAHubCompanionMulticallHandlerMock is DCAHubCompanionMulticallHandler, DCAHubCompanionParametersMock {
+  constructor(IDCAHub _hub, IDCAPermissionManager _permissionManager)
+    DCAHubCompanionParametersMock(_hub, _permissionManager, IWrappedProtocolToken(address(1)), address(1))
+  {}
+}

--- a/contracts/mocks/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
+++ b/contracts/mocks/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
@@ -5,7 +5,9 @@ import '../../DCAHubCompanion/DCAHubCompanionMulticallHandler.sol';
 import './DCAHubCompanionParameters.sol';
 
 contract DCAHubCompanionMulticallHandlerMock is DCAHubCompanionMulticallHandler, DCAHubCompanionParametersMock {
-  constructor(IDCAHub _hub, IDCAPermissionManager _permissionManager)
-    DCAHubCompanionParametersMock(_hub, _permissionManager, IWrappedProtocolToken(address(1)), address(1))
-  {}
+  constructor(
+    IDCAHub _hub,
+    IDCAPermissionManager _permissionManager,
+    address _governor
+  ) DCAHubCompanionParametersMock(_hub, _permissionManager, IWrappedProtocolToken(address(1)), _governor) {}
 }

--- a/contracts/mocks/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
+++ b/contracts/mocks/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
@@ -8,6 +8,7 @@ contract DCAHubCompanionWTokenPositionHandlerMock is DCAHubCompanionWTokenPositi
   constructor(
     IDCAHub _hub,
     IDCAPermissionManager _permissionManager,
-    IWrappedProtocolToken _wToken
-  ) DCAHubCompanionParametersMock(_hub, _permissionManager, _wToken, address(1)) {}
+    IWrappedProtocolToken _wToken,
+    address _governor
+  ) DCAHubCompanionParametersMock(_hub, _permissionManager, _wToken, _governor) {}
 }

--- a/deploy/000_register_hub.ts
+++ b/deploy/000_register_hub.ts
@@ -9,6 +9,7 @@ import {
 } from '@mean-finance/dca-v2-core/artifacts/contracts/oracles/ChainlinkOracle.sol/ChainlinkOracle.json';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from 'hardhat-deploy/types';
+import { BigNumber } from 'ethers/lib/ethers';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // TODO: Use address from npm package when exposed
@@ -28,7 +29,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     const chainlinkDeployment = await hre.deployments.deploy('Oracle', {
       from: deployer,
       contract: { abi: CHAINLINK_ABI, bytecode: CHAINLINK_BYTECODE },
-      args: [WETH, CHAINLINK_REGISTRY, governor],
+      args: [WETH, CHAINLINK_REGISTRY, BigNumber.from(2).pow(32).sub(1), governor],
     });
     const permissionsManagerDeployment = await hre.deployments.deploy('PermissionsManager', {
       from: deployer,

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "postpublish": "pinst --enable"
   },
   "dependencies": {
-    "@mean-finance/dca-v2-core": "^1.0.0-rc.8"
+    "@mean-finance/dca-v2-core": "^1.0.0-rc.9"
   },
   "devDependencies": {
     "@codechecks/client": "0.1.11",

--- a/test/integration/DCAHubCompanion/multi-call.spec.ts
+++ b/test/integration/DCAHubCompanion/multi-call.spec.ts
@@ -1,0 +1,462 @@
+import { expect } from 'chai';
+import { deployments, ethers, getNamedAccounts } from 'hardhat';
+import { TransactionResponse } from '@ethersproject/providers';
+import { behaviours, constants, wallet } from '@test-utils';
+import { given, then, when } from '@test-utils/bdd';
+import evm, { snapshot } from '@test-utils/evm';
+import { DCAHubCompanion, IERC20 } from '@typechained';
+import { DCAHub, DCAPermissionsManager } from '@mean-finance/dca-v2-core/typechained';
+import { abi as DCA_HUB_ABI } from '@mean-finance/dca-v2-core/artifacts/contracts/DCAHub/DCAHub.sol/DCAHub.json';
+import { getNodeUrl } from '@utils/network';
+import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
+import { BigNumber, utils } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
+import { SwapInterval } from '@test-utils/interval-utils';
+import forkBlockNumber from '@integration/fork-block-numbers';
+import { fromRpcSig } from 'ethereumjs-util';
+
+const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const WETH_WHALE_ADDRESS = '0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e';
+const USDC_WHALE_ADDRESS = '0x0a59649758aa4d66e25f08dd01271e891fe52199';
+
+describe('Multicall', () => {
+  let WETH: IERC20, USDC: IERC20;
+  let positionOwner: SignerWithAddress, swapper: SignerWithAddress, recipient: SignerWithAddress;
+  let DCAHubCompanion: DCAHubCompanion;
+  let DCAPermissionManager: DCAPermissionsManager;
+  let DCAHub: DCAHub;
+  let initialRecipientProtocolBalance: BigNumber;
+  let chainId: BigNumber;
+  let snapshotId: string;
+
+  const RATE = BigNumber.from(100000000);
+  const AMOUNT_OF_SWAPS = 10;
+
+  before(async () => {
+    await evm.reset({
+      jsonRpcUrl: getNodeUrl('mainnet'),
+      blockNumber: forkBlockNumber['wtoken'],
+    });
+    [positionOwner, swapper, recipient] = await ethers.getSigners();
+
+    await deployments.fixture('DCAHubCompanion', { keepExistingDeployments: false });
+    DCAHub = await ethers.getContract('DCAHub');
+    DCAHubCompanion = await ethers.getContract('DCAHubCompanion');
+    DCAPermissionManager = await ethers.getContract('PermissionsManager');
+
+    const namedAccounts = await getNamedAccounts();
+    const governorAddress = namedAccounts.governor;
+    const governor = await wallet.impersonate(governorAddress);
+    await ethers.provider.send('hardhat_setBalance', [governorAddress, '0xffffffffffffffff']);
+
+    // Allow one minute interval
+    await DCAHub.connect(governor).addSwapIntervalsToAllowedList([SwapInterval.ONE_MINUTE.seconds]);
+
+    WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
+    USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);
+
+    // Send tokens from whales, to our users
+    await distributeTokensToUsers();
+
+    initialRecipientProtocolBalance = await ethers.provider.getBalance(recipient.address);
+    chainId = BigNumber.from((await ethers.provider.getNetwork()).chainId);
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('protocol token as "from"', () => {
+    when('reducing a position with protocol token', () => {
+      const AMOUNT_TO_REDUCE = RATE.mul(AMOUNT_OF_SWAPS).div(2);
+      let positionId: BigNumber;
+      let hubWTokenBalanceAfterDeposit: BigNumber;
+      given(async () => {
+        positionId = await depositWithWTokenAsFrom();
+        hubWTokenBalanceAfterDeposit = await WETH.balanceOf(DCAHub.address);
+
+        const permissionData = await addPermissionToCompanionData(positionOwner, positionId, Permission.REDUCE);
+        const { data: reduceData } = await DCAHubCompanion.populateTransaction.reducePositionUsingProtocolToken(
+          positionId,
+          AMOUNT_TO_REDUCE,
+          AMOUNT_OF_SWAPS,
+          recipient.address
+        );
+        await DCAHubCompanion.multicall([permissionData, reduceData!]);
+      });
+      then('position is reduced', async () => {
+        const userPosition = await DCAHub.userPosition(positionId);
+        expect(userPosition.from).to.equal(WETH_ADDRESS);
+        expect(userPosition.rate).to.equal(RATE.div(2));
+        expect(userPosition.swapsLeft).to.equal(AMOUNT_OF_SWAPS);
+      });
+      then(`hub's wToken balance is reduced`, async () => {
+        const balance = await WETH.balanceOf(DCAHub.address);
+        expect(balance).to.equal(hubWTokenBalanceAfterDeposit.sub(AMOUNT_TO_REDUCE));
+      });
+      then(`recipients's protocol balance increases`, async () => {
+        const balance = await ethers.provider.getBalance(recipient.address);
+        expect(balance).to.equal(initialRecipientProtocolBalance.add(AMOUNT_TO_REDUCE));
+      });
+      thenCompanionRemainsWithoutAnyBalance();
+    });
+
+    when(`terminating a position with protocol token as 'from'`, () => {
+      const AMOUNT_RETURNED = RATE.mul(AMOUNT_OF_SWAPS);
+      let positionId: BigNumber;
+      let hubWTokenBalanceAfterDeposit: BigNumber;
+      given(async () => {
+        positionId = await depositWithWTokenAsFrom();
+        hubWTokenBalanceAfterDeposit = await WETH.balanceOf(DCAHub.address);
+        const permissionData = await addPermissionToCompanionData(positionOwner, positionId, Permission.TERMINATE);
+        const { data: terminateData } = await DCAHubCompanion.populateTransaction.terminateUsingProtocolTokenAsFrom(
+          positionId,
+          recipient.address,
+          recipient.address
+        );
+        await DCAHubCompanion.multicall([permissionData, terminateData!]);
+      });
+      then('position is terminated', async () => {
+        const userPosition = await DCAHub.userPosition(positionId);
+        expect(userPosition.swapInterval).to.equal(0);
+      });
+      then(`hub's wToken balance is reduced`, async () => {
+        const balance = await WETH.balanceOf(DCAHub.address);
+        expect(balance).to.equal(hubWTokenBalanceAfterDeposit.sub(AMOUNT_RETURNED));
+      });
+      then(`recipients's protocol balance increases`, async () => {
+        const balance = await ethers.provider.getBalance(recipient.address);
+        expect(balance).to.equal(initialRecipientProtocolBalance.add(AMOUNT_RETURNED));
+      });
+      thenCompanionRemainsWithoutAnyBalance();
+    });
+  });
+
+  describe('protocol token as "to"', () => {
+    when('withdrawing from a position', () => {
+      let positionId: BigNumber;
+      let swappedBalance: BigNumber;
+      let hubWTokenBalanceAfterSwap: BigNumber;
+      given(async () => {
+        ({ positionId, swappedBalance } = await depositWithWTokenAsToAndSwap());
+        hubWTokenBalanceAfterSwap = await WETH.balanceOf(DCAHub.address);
+        const permissionData = await addPermissionToCompanionData(positionOwner, positionId, Permission.WITHDRAW);
+        const { data: withdrawData } = await DCAHubCompanion.populateTransaction.withdrawSwappedUsingProtocolToken(
+          positionId,
+          recipient.address
+        );
+        await DCAHubCompanion.multicall([permissionData, withdrawData!]);
+      });
+      then('position has no more swapped balance', async () => {
+        const userPosition = await DCAHub.userPosition(positionId);
+        expect(userPosition.swapped).to.equal(0);
+      });
+      then(`hub's wToken balance is reduced`, async () => {
+        const balance = await WETH.balanceOf(DCAHub.address);
+        expect(balance).to.equal(hubWTokenBalanceAfterSwap.sub(swappedBalance));
+      });
+      then(`recipients's protocol balance increases`, async () => {
+        const balance = await ethers.provider.getBalance(recipient.address);
+        expect(balance).to.equal(initialRecipientProtocolBalance.add(swappedBalance));
+      });
+      thenCompanionRemainsWithoutAnyBalance();
+    });
+
+    when('withdrawing many from a position', () => {
+      let positionId: BigNumber;
+      let swappedBalance: BigNumber;
+      let hubWTokenBalanceAfterSwap: BigNumber;
+      given(async () => {
+        ({ positionId, swappedBalance } = await depositWithWTokenAsToAndSwap());
+        hubWTokenBalanceAfterSwap = await WETH.balanceOf(DCAHub.address);
+        const permissionData = await addPermissionToCompanionData(positionOwner, positionId, Permission.WITHDRAW);
+        const { data: withdrawData } = await DCAHubCompanion.populateTransaction.withdrawSwappedManyUsingProtocolToken(
+          [positionId],
+          recipient.address
+        );
+        await DCAHubCompanion.multicall([permissionData, withdrawData!]);
+      });
+      then('position has no more swapped balance', async () => {
+        const userPosition = await DCAHub.userPosition(positionId);
+        expect(userPosition.swapped).to.equal(0);
+      });
+      then(`hub's wToken balance is reduced`, async () => {
+        const balance = await WETH.balanceOf(DCAHub.address);
+        expect(balance).to.equal(hubWTokenBalanceAfterSwap.sub(swappedBalance));
+      });
+      then(`recipients's protocol balance increases`, async () => {
+        const balance = await ethers.provider.getBalance(recipient.address);
+        expect(balance).to.equal(initialRecipientProtocolBalance.add(swappedBalance));
+      });
+      thenCompanionRemainsWithoutAnyBalance();
+    });
+
+    when(`terminating a position with protocol token as 'to'`, () => {
+      let positionId: BigNumber;
+      let swappedBalance: BigNumber;
+      let hubWTokenBalanceAfterSwap: BigNumber;
+      given(async () => {
+        ({ positionId, swappedBalance } = await depositWithWTokenAsToAndSwap());
+        hubWTokenBalanceAfterSwap = await WETH.balanceOf(DCAHub.address);
+        const permissionData = await addPermissionToCompanionData(positionOwner, positionId, Permission.TERMINATE);
+        const { data: terminateData } = await DCAHubCompanion.populateTransaction.terminateUsingProtocolTokenAsTo(
+          positionId,
+          recipient.address,
+          recipient.address
+        );
+        await DCAHubCompanion.multicall([permissionData, terminateData!]);
+      });
+      then('position is terminated', async () => {
+        const userPosition = await DCAHub.userPosition(positionId);
+        expect(userPosition.swapInterval).to.equal(0);
+      });
+      then(`hub's wToken balance is reduced`, async () => {
+        const balance = await WETH.balanceOf(DCAHub.address);
+        expect(balance).to.equal(hubWTokenBalanceAfterSwap.sub(swappedBalance));
+      });
+      then(`recipients's protocol balance increases`, async () => {
+        const balance = await ethers.provider.getBalance(recipient.address);
+        expect(balance).to.equal(initialRecipientProtocolBalance.add(swappedBalance));
+      });
+      thenCompanionRemainsWithoutAnyBalance();
+    });
+  });
+
+  when('trying to withdraw swapped and unswapped balance in one tx', () => {
+    let positionId: BigNumber;
+    let swappedBalance: BigNumber, unswappedBalance: BigNumber;
+    let hubFromTokenBalanceAfterSwap: BigNumber, hubToTokenBalanceAfterSwap: BigNumber;
+    given(async () => {
+      ({ positionId, swappedBalance, unswappedBalance } = await depositWithWTokenAsToAndSwap());
+      hubFromTokenBalanceAfterSwap = await USDC.balanceOf(DCAHub.address);
+      hubToTokenBalanceAfterSwap = await WETH.balanceOf(DCAHub.address);
+      const permissionData = await addPermissionToCompanionData(positionOwner, positionId, Permission.REDUCE, Permission.WITHDRAW);
+      const { data: reduceData } = await DCAHubCompanion.populateTransaction.reducePositionProxy(
+        positionId,
+        unswappedBalance,
+        0,
+        recipient.address
+      );
+      const { data: withdrawData } = await DCAHubCompanion.populateTransaction.withdrawSwappedProxy(positionId, recipient.address);
+      await DCAHubCompanion.multicall([permissionData, reduceData!, withdrawData!]);
+    });
+    then(`hub's FROM balance is reduced`, async () => {
+      const balance = await USDC.balanceOf(DCAHub.address);
+      expect(balance).to.equal(hubFromTokenBalanceAfterSwap.sub(unswappedBalance));
+    });
+    then(`hub's TO balance is reduced`, async () => {
+      const balance = await WETH.balanceOf(DCAHub.address);
+      expect(balance).to.equal(hubToTokenBalanceAfterSwap.sub(swappedBalance));
+    });
+    then(`recipients's FROM increases`, async () => {
+      const balance = await USDC.balanceOf(recipient.address);
+      expect(balance).to.equal(unswappedBalance);
+    });
+    then(`recipients's TO increases`, async () => {
+      const balance = await WETH.balanceOf(recipient.address);
+      expect(balance).to.equal(swappedBalance);
+    });
+    thenCompanionRemainsWithoutAnyBalance();
+  });
+
+  when('trying to withdraw swapped and create a new position with it', () => {
+    let positionId: BigNumber;
+    let swappedBalance: BigNumber;
+    let hubWETHBalanceAfterSwap: BigNumber;
+    given(async () => {
+      ({ positionId, swappedBalance } = await depositWithWTokenAsToAndSwap());
+      hubWETHBalanceAfterSwap = await WETH.balanceOf(DCAHub.address);
+      const permissionData = await addPermissionToCompanionData(positionOwner, positionId, Permission.WITHDRAW);
+      const { data: withdrawData } = await DCAHubCompanion.populateTransaction.withdrawSwappedProxy(positionId, DCAHubCompanion.address);
+      const { data: depositData } = await DCAHubCompanion.populateTransaction.depositProxy(
+        WETH.address,
+        USDC.address,
+        swappedBalance,
+        1,
+        SwapInterval.ONE_MINUTE.seconds,
+        positionOwner.address,
+        [],
+        false
+      );
+
+      await DCAHubCompanion.multicall([permissionData, withdrawData!, depositData!]);
+    });
+    then(`hub's WETH balance stays the same`, async () => {
+      const balance = await WETH.balanceOf(DCAHub.address);
+      expect(balance).to.equal(hubWETHBalanceAfterSwap);
+    });
+    then(`original position has nothing left to withdraw`, async () => {
+      const { swapped } = await DCAHub.userPosition(positionId);
+      expect(swapped).to.equal(0);
+    });
+    then(`new position is created`, async () => {
+      const { from, to, swapsExecuted, remaining } = await DCAHub.userPosition(positionId.add(1));
+      expect(from.toLowerCase()).to.eql(WETH.address.toLowerCase());
+      expect(to.toLowerCase()).to.equal(USDC.address.toLowerCase());
+      expect(swapsExecuted).to.equal(0);
+      expect(remaining).to.equal(swappedBalance);
+    });
+    then(`owner is correctly assigned`, async () => {
+      expect(await DCAPermissionManager.ownerOf(positionId.add(1))).to.equal(positionOwner.address);
+    });
+    thenCompanionRemainsWithoutAnyBalance();
+  });
+
+  when('trying to use an invalid permit through multicall', () => {
+    let tx: Promise<TransactionResponse>;
+    let permissionData: string;
+
+    given(async () => {
+      const positionId = await depositWithWTokenAsFrom();
+      permissionData = await addPermissionToCompanionData(recipient, positionId, Permission.REDUCE);
+    });
+    then('reverts with message', async () => {
+      await behaviours.txShouldRevertWithMessage({
+        contract: DCAHubCompanion,
+        func: 'multicall',
+        args: [[permissionData]],
+        message: 'VM Exception while processing transaction: reverted with an unrecognized custom error',
+      });
+    });
+  });
+
+  function thenCompanionRemainsWithoutAnyBalance() {
+    then('companion continues without wToken balance', async () => {
+      const balance = await WETH.balanceOf(DCAHubCompanion.address);
+      expect(balance).to.equal(0);
+    });
+    then('companion continues without platform balance', async () => {
+      const balance = await ethers.provider.getBalance(DCAHubCompanion.address);
+      expect(balance).to.equal(0);
+    });
+  }
+
+  async function distributeTokensToUsers() {
+    const wethWhale = await wallet.impersonate(WETH_WHALE_ADDRESS);
+    const usdcWhale = await wallet.impersonate(USDC_WHALE_ADDRESS);
+    await ethers.provider.send('hardhat_setBalance', [WETH_WHALE_ADDRESS, '0xffffffffffffffff']);
+    await ethers.provider.send('hardhat_setBalance', [USDC_WHALE_ADDRESS, '0xffffffffffffffff']);
+    await WETH.connect(wethWhale).transfer(swapper.address, BigNumber.from(10).pow(23));
+    await WETH.connect(wethWhale).transfer(positionOwner.address, BigNumber.from(10).pow(23));
+    await USDC.connect(usdcWhale).transfer(positionOwner.address, BigNumber.from(10).pow(12));
+    await USDC.connect(usdcWhale).transfer(swapper.address, BigNumber.from(10).pow(12));
+  }
+
+  async function depositWithWTokenAsFrom() {
+    await WETH.connect(positionOwner).approve(DCAHub.address, RATE.mul(AMOUNT_OF_SWAPS));
+    const tx = await DCAHub.connect(positionOwner).deposit(
+      WETH.address,
+      USDC.address,
+      RATE.mul(AMOUNT_OF_SWAPS),
+      AMOUNT_OF_SWAPS,
+      SwapInterval.ONE_MINUTE.seconds,
+      positionOwner.address,
+      []
+    );
+    const event = await getHubEvent(tx, 'Deposited');
+    return event.args.positionId;
+  }
+
+  async function depositWithWTokenAsToAndSwap() {
+    await USDC.connect(positionOwner).approve(DCAHub.address, constants.MAX_UINT_256);
+    const tx = await DCAHub.connect(positionOwner).deposit(
+      USDC.address,
+      WETH.address,
+      RATE.mul(AMOUNT_OF_SWAPS),
+      AMOUNT_OF_SWAPS,
+      SwapInterval.ONE_MINUTE.seconds,
+      positionOwner.address,
+      []
+    );
+    const event = await getHubEvent(tx, 'Deposited');
+    const positionId = event.args.positionId;
+
+    await WETH.connect(swapper).approve(DCAHubCompanion.address, constants.MAX_UINT_256);
+    await DCAHubCompanion.connect(swapper).swapForCaller(
+      [USDC_ADDRESS, WETH_ADDRESS],
+      [{ indexTokenA: 0, indexTokenB: 1 }],
+      [0, 0],
+      [constants.MAX_UINT_256, constants.MAX_UINT_256],
+      swapper.address,
+      constants.MAX_UINT_256
+    );
+
+    const { swapped } = await DCAHub.userPosition(positionId);
+    return { positionId, swappedBalance: swapped, unswappedBalance: RATE.mul(AMOUNT_OF_SWAPS - 1) };
+  }
+
+  function getHubEvent(tx: TransactionResponse, name: string): Promise<utils.LogDescription> {
+    return findLogs(tx, new utils.Interface(DCA_HUB_ABI), name);
+  }
+
+  async function findLogs(
+    tx: TransactionResponse,
+    contractInterface: utils.Interface,
+    eventTopic: string,
+    extraFilter?: (_: utils.LogDescription) => boolean
+  ): Promise<utils.LogDescription> {
+    const txReceipt = await tx.wait();
+    const logs = txReceipt.logs;
+    for (let i = 0; i < logs.length; i++) {
+      for (let x = 0; x < logs[i].topics.length; x++) {
+        if (logs[i].topics[x] === contractInterface.getEventTopic(eventTopic)) {
+          const parsedLog = contractInterface.parseLog(logs[i]);
+          if (!extraFilter || extraFilter(parsedLog)) {
+            return parsedLog;
+          }
+        }
+      }
+    }
+    return Promise.reject();
+  }
+
+  async function addPermissionToCompanionData(signer: SignerWithAddress, tokenId: BigNumber, ...permissions: Permission[]) {
+    const permissionsStruct = [{ operator: DCAHubCompanion.address, permissions }];
+    const { v, r, s } = await getSignature(signer, tokenId, permissionsStruct);
+    const { data } = await DCAHubCompanion.populateTransaction.permissionPermitProxy(
+      permissionsStruct,
+      tokenId,
+      constants.MAX_UINT_256,
+      v,
+      r,
+      s
+    );
+    return data!;
+  }
+
+  const PermissionSet = [
+    { name: 'operator', type: 'address' },
+    { name: 'permissions', type: 'uint8[]' },
+  ];
+
+  const PermissionPermit = [
+    { name: 'permissions', type: 'PermissionSet[]' },
+    { name: 'tokenId', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ];
+
+  async function getSignature(signer: SignerWithAddress, tokenId: BigNumber, permissions: { operator: string; permissions: Permission[] }[]) {
+    const { domain, types, value } = buildPermitData(tokenId, permissions);
+    const signature = await signer._signTypedData(domain, types, value);
+    return fromRpcSig(signature);
+  }
+
+  function buildPermitData(tokenId: BigNumber, permissions: { operator: string; permissions: Permission[] }[]) {
+    return {
+      primaryType: 'PermissionPermit',
+      types: { PermissionSet, PermissionPermit },
+      domain: { name: 'Mean Finance DCA', version: '1', chainId, verifyingContract: DCAPermissionManager.address },
+      value: { tokenId, permissions, nonce: 0, deadline: constants.MAX_UINT_256 },
+    };
+  }
+
+  enum Permission {
+    INCREASE,
+    REDUCE,
+    WITHDRAW,
+    TERMINATE,
+  }
+});

--- a/test/integration/fork-block-numbers.ts
+++ b/test/integration/fork-block-numbers.ts
@@ -1,6 +1,7 @@
 const forkBlockNumber = {
   'swap-for-caller': 13651969,
   wtoken: 13651969,
+  multicall: 13651969,
 };
 
 export default forkBlockNumber;

--- a/test/unit/DCAHubCompanion/dca-hub-companion-multi-call-handler.spec.ts
+++ b/test/unit/DCAHubCompanion/dca-hub-companion-multi-call-handler.spec.ts
@@ -1,0 +1,152 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { constants } from '@test-utils';
+import { contract, given, then, when } from '@test-utils/bdd';
+import { snapshot } from '@test-utils/evm';
+import {
+  DCAHubCompanionMulticallHandlerMock,
+  DCAHubCompanionMulticallHandlerMock__factory,
+  IDCAHub,
+  IDCAPermissionManager,
+  IERC20,
+} from '@typechained';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+
+chai.use(smock.matchers);
+
+contract('DCAHubCompanionMulticallHandler', () => {
+  let DCAPermissionManager: FakeContract<IDCAPermissionManager>;
+  let DCAHub: FakeContract<IDCAHub>;
+  let erc20Token: FakeContract<IERC20>;
+  let DCAHubCompanionMulticallHandler: DCAHubCompanionMulticallHandlerMock;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    const DCAHubCompanionMulticallHandlerFactory: DCAHubCompanionMulticallHandlerMock__factory = await ethers.getContractFactory(
+      'contracts/mocks/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol:DCAHubCompanionMulticallHandlerMock'
+    );
+    DCAPermissionManager = await smock.fake('IDCAPermissionManager');
+    DCAHub = await smock.fake('IDCAHub');
+    erc20Token = await smock.fake('IERC20');
+    DCAHubCompanionMulticallHandler = await DCAHubCompanionMulticallHandlerFactory.deploy(DCAHub.address, DCAPermissionManager.address);
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+    erc20Token.transferFrom.returns(true);
+    DCAHub.userPosition.returns({
+      from: erc20Token.address,
+      to: constants.NOT_ZERO_ADDRESS,
+      swapInterval: 10,
+      swapsExecuted: 10,
+      swapped: 10,
+      swapsLeft: 10,
+      remaining: 10,
+      rate: 10,
+    });
+  });
+  afterEach(() => {
+    erc20Token.approve.reset();
+    DCAPermissionManager.hasPermission.reset();
+    DCAHub.deposit.reset();
+    DCAHub.withdrawSwapped.reset();
+    DCAHub.withdrawSwappedMany.reset();
+    DCAHub.increasePosition.reset();
+    DCAHub.reducePosition.reset();
+    DCAHub.terminate.reset();
+  });
+
+  enum Permission {
+    INCREASE,
+    REDUCE,
+    WITHDRAW,
+    TERMINATE,
+  }
+
+  proxyTest({
+    method: 'withdrawSwappedProxy',
+    hubMethod: 'withdrawSwapped',
+    permission: Permission.WITHDRAW,
+    params: [10, constants.NOT_ZERO_ADDRESS],
+  });
+
+  proxyTest({
+    method: 'withdrawSwappedManyProxy',
+    hubMethod: 'withdrawSwappedMany',
+    permission: Permission.WITHDRAW,
+    params: [[{ token: constants.NOT_ZERO_ADDRESS, positionIds: [1] }], constants.NOT_ZERO_ADDRESS],
+    compare: (result, [positions, recipient]) =>
+      result._positions.length === positions.length &&
+      result._positions[0].token === positions[0].token &&
+      result._positions[0].positionIds.length === positions[0].positionIds.length &&
+      result._positions[0].positionIds[0].toNumber() === positions[0].positionIds[0] &&
+      result._recipient === recipient,
+  });
+
+  proxyTest({
+    method: 'increasePositionProxy',
+    hubMethod: 'increasePosition',
+    permission: Permission.INCREASE,
+    params: [10, 20, 30],
+  });
+
+  proxyTest({
+    method: 'reducePositionProxy',
+    hubMethod: 'reducePosition',
+    permission: Permission.REDUCE,
+    params: [10, 20, 30, constants.NOT_ZERO_ADDRESS],
+  });
+
+  proxyTest({
+    method: 'terminateProxy',
+    hubMethod: 'terminate',
+    permission: Permission.TERMINATE,
+    params: [10, constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS],
+  });
+
+  function proxyTest<
+    ProxyMethod extends keyof DCAHubCompanionMulticallHandlerMock['functions'] & string,
+    HubMethod extends keyof FakeContract<IDCAHub>
+  >({
+    method,
+    permission,
+    params,
+    hubMethod,
+    compare,
+  }: {
+    method: ProxyMethod;
+    permission: Permission;
+    params: Parameters<DCAHubCompanionMulticallHandlerMock['functions'][ProxyMethod]>;
+    hubMethod: HubMethod;
+    compare?: (result: any, expected: Parameters<DCAHubCompanionMulticallHandlerMock['functions'][ProxyMethod]>) => boolean;
+  }) {
+    describe(method, () => {
+      when('method is executed', () => {
+        given(async () => {
+          DCAPermissionManager.hasPermission.returns(({ _permission }: { _permission: Permission }) => permission === _permission);
+          await (DCAHubCompanionMulticallHandler[method] as any)(...params);
+        });
+        then('hub is called', () => {
+          if (compare) {
+            expect(DCAHub[hubMethod]).to.have.been.calledOnce;
+            const args: unknown[] = (DCAHub[hubMethod] as any).getCall(0).args;
+            expect(compare(args, params)).to.be.true;
+          } else {
+            expect(DCAHub[hubMethod]).to.have.been.calledOnceWith(...params);
+          }
+        });
+      });
+      when('caller does not have permission', () => {
+        given(() => {
+          DCAPermissionManager.hasPermission.returns(() => false);
+        });
+        then('operation is reverted', async () => {
+          const result: Promise<TransactionResponse> = (DCAHubCompanionMulticallHandler[method] as any)(...params);
+          await expect(result).to.be.revertedWith('UnauthorizedCaller');
+        });
+      });
+    });
+  }
+});

--- a/test/unit/DCAHubCompanion/dca-hub-companion-wtoken-position-handler.spec.ts
+++ b/test/unit/DCAHubCompanion/dca-hub-companion-wtoken-position-handler.spec.ts
@@ -45,7 +45,6 @@ contract('DCAHubCompanionWTokenPositionHandler', () => {
     wToken = await wTokenFactory.deploy('WETH', 'WETH', 18);
     DCAPermissionManager = await smock.fake('IDCAPermissionManager');
     DCAHub = await smock.fake('IDCAHub');
-    DCAHub.permissionManager.returns(DCAPermissionManager.address);
     erc20Token = await smock.fake('IERC20');
     DCAHubCompanionWTokenPositionHandler = await DCAHubCompanionWTokenPositionHandlerFactory.deploy(
       DCAHub.address,

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,10 +736,10 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@mean-finance/dca-v2-core@^1.0.0-rc.8":
-  version "1.0.0-rc.8"
-  resolved "https://registry.yarnpkg.com/@mean-finance/dca-v2-core/-/dca-v2-core-1.0.0-rc.8.tgz#d1cde7e4847a3a3e4679bb826d717f2599282d8d"
-  integrity sha512-51d4xiKCjQmOpFEy2LZmI7KQdRJCRFWu4GXlH2zCBrtWUvZYjh1/T23JRGVjZdPqLBhbN84tt2EMZn0tY+n+cg==
+"@mean-finance/dca-v2-core@^1.0.0-rc.9":
+  version "1.0.0-rc.9"
+  resolved "https://registry.yarnpkg.com/@mean-finance/dca-v2-core/-/dca-v2-core-1.0.0-rc.9.tgz#e5ec042a84c4ddbf8db3dd74955538e003b1253c"
+  integrity sha512-rC+pQ46E05VdYGBLDeiyJQTUQwpuCGxGUkxG2uibVm+yXkTVooI5dkBOgldIUW+EVOm1r7B7/njHLj9N5VaUvA==
   dependencies:
     "@chainlink/contracts" "^0.2.2"
     "@openzeppelin/contracts" "4.3.2"


### PR DESCRIPTION
We are now making the first step towards adding the multicall handler. The idea is to support multiple calls in one tx, like:
- Give the companion permissions and withdraw as eth
- Execute withdraws from swapped and unswapped balance in one tx, without terminating

In order to support these use cases, we need to add calls these "proxy calls" in the companion, so we can then use them in the multicall