### PR TITLE
refactor: support tokens with approval issues

### DIFF
--- a/contracts/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
@@ -32,7 +32,9 @@ abstract contract DCAHubCompanionMulticallHandler is Multicall, DCAHubCompanionP
     if (_transferFromCaller) {
       IERC20Metadata(_from).safeTransferFrom(msg.sender, address(this), _amount);
     }
-    IERC20Metadata(_from).approve(address(hub), _amount);
+    // If the token we are going to approve doesn't have the approval issue we see in USDT, we will approve 1 extra.
+    // We are doing that so that the allowance isn't fully spent, and the next approve is cheaper.
+    IERC20Metadata(_from).approve(address(hub), tokenHasApprovalIssue[_from] ? _amount : _amount + 1);
     _positionId = hub.deposit(_from, _to, _amount, _amountOfSwaps, _swapInterval, _owner, _permissions);
   }
 
@@ -67,7 +69,9 @@ abstract contract DCAHubCompanionMulticallHandler is Multicall, DCAHubCompanionP
     if (_transferFromCaller) {
       _from.safeTransferFrom(msg.sender, address(this), _amount);
     }
-    _from.approve(address(hub), _amount);
+    // If the token we are going to approve doesn't have the approval issue we see in USDT, we will approve 1 extra.
+    // We are doing that so that the allowance isn't fully spent, and the next approve is cheaper.
+    _from.approve(address(hub), tokenHasApprovalIssue[address(_from)] ? _amount : _amount + 1);
     hub.increasePosition(_positionId, _amount, _newSwaps);
   }
 

--- a/contracts/DCAHubCompanion/DCAHubCompanionParameters.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionParameters.sol
@@ -31,4 +31,19 @@ abstract contract DCAHubCompanionParameters is Governable, IDCAHubCompanionParam
     }
     emit TokenWithApprovalIssuesSet(_addresses, _hasIssue);
   }
+
+  function _checkPermissionOrFail(uint256 _positionId, IDCAPermissionManager.Permission _permission) internal view {
+    if (!permissionManager.hasPermission(_positionId, msg.sender, _permission)) revert IDCAHubCompanion.UnauthorizedCaller();
+  }
+
+  function _approveHub(address _from, uint256 _amount) internal {
+    // If the token we are going to approve doesn't have the approval issue we see in USDT, we will approve 1 extra.
+    // We are doing that so that the allowance isn't fully spent, and the next approve is cheaper.
+    IERC20(_from).approve(address(hub), tokenHasApprovalIssue[_from] ? _amount : _amount + 1);
+  }
+
+  modifier checkPermission(uint256 _positionId, IDCAPermissionManager.Permission _permission) {
+    _checkPermissionOrFail(_positionId, _permission);
+    _;
+  }
 }

--- a/contracts/DCAHubCompanion/DCAHubCompanionParameters.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionParameters.sol
@@ -9,6 +9,7 @@ abstract contract DCAHubCompanionParameters is Governable, IDCAHubCompanionParam
   IDCAPermissionManager public immutable permissionManager;
   IWrappedProtocolToken public immutable wToken;
   address public constant PROTOCOL_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+  mapping(address => bool) public tokenHasApprovalIssue;
 
   constructor(
     IDCAHub _hub,
@@ -21,5 +22,13 @@ abstract contract DCAHubCompanionParameters is Governable, IDCAHubCompanionParam
     hub = _hub;
     wToken = _wToken;
     permissionManager = _permissionManager;
+  }
+
+  function setTokensWithApprovalIssues(address[] calldata _addresses, bool[] calldata _hasIssue) external onlyGovernor {
+    if (_addresses.length != _hasIssue.length) revert InvalidTokenApprovalParams();
+    for (uint256 i; i < _addresses.length; i++) {
+      tokenHasApprovalIssue[_addresses[i]] = _hasIssue[i];
+    }
+    emit TokenWithApprovalIssuesSet(_addresses, _hasIssue);
   }
 }

--- a/contracts/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
@@ -30,9 +30,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
       _convertedFrom = address(wToken);
     } else {
       IERC20(_from).safeTransferFrom(msg.sender, address(this), _amount);
-      // If the token we are going to approve doesn't have the approval issue we see in USDT, we will approve 1 extra.
-      // We are doing that so that the allowance isn't fully spent, and the next approve is cheaper.
-      IERC20(_from).approve(address(hub), tokenHasApprovalIssue[_from] ? _amount : _amount + 1);
+      _approveHub(_from, _amount);
       _convertedTo = address(wToken);
     }
 
@@ -50,9 +48,11 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     emit ConvertedDeposit(_positionId, _from, _convertedFrom, _to, _convertedTo);
   }
 
-  function withdrawSwappedUsingProtocolToken(uint256 _positionId, address payable _recipient) external returns (uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  function withdrawSwappedUsingProtocolToken(uint256 _positionId, address payable _recipient)
+    external
+    checkPermission(_positionId, IDCAPermissionManager.Permission.WITHDRAW)
+    returns (uint256 _swapped)
+  {
     _swapped = hub.withdrawSwapped(_positionId, address(this));
     _unwrapAndSend(_swapped, _recipient);
   }
@@ -62,8 +62,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     returns (uint256 _swapped)
   {
     for (uint256 i; i < _positionIds.length; i++) {
-      if (!permissionManager.hasPermission(_positionIds[i], msg.sender, IDCAPermissionManager.Permission.WITHDRAW))
-        revert IDCAHubCompanion.UnauthorizedCaller();
+      _checkPermissionOrFail(_positionIds[i], IDCAPermissionManager.Permission.WITHDRAW);
     }
     IDCAHub.PositionSet[] memory _positionSets = new IDCAHub.PositionSet[](1);
     _positionSets[0].token = address(wToken);
@@ -77,9 +76,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint256 _positionId,
     uint256 _amount,
     uint32 _newSwaps
-  ) external payable {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.INCREASE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external payable checkPermission(_positionId, IDCAPermissionManager.Permission.INCREASE) {
     _wrap(_amount);
     hub.increasePosition(_positionId, _amount, _newSwaps);
   }
@@ -89,9 +86,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint256 _amount,
     uint32 _newSwaps,
     address payable _recipient
-  ) external {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.REDUCE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external checkPermission(_positionId, IDCAPermissionManager.Permission.REDUCE) {
     hub.reducePosition(_positionId, _amount, _newSwaps, address(this));
     _unwrapAndSend(_amount, _recipient);
   }
@@ -100,9 +95,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint256 _positionId,
     address payable _recipientUnswapped,
     address _recipientSwapped
-  ) external returns (uint256 _unswapped, uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external checkPermission(_positionId, IDCAPermissionManager.Permission.TERMINATE) returns (uint256 _unswapped, uint256 _swapped) {
     (_unswapped, _swapped) = hub.terminate(_positionId, address(this), _recipientSwapped);
     _unwrapAndSend(_unswapped, _recipientUnswapped);
   }
@@ -111,9 +104,7 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
     uint256 _positionId,
     address _recipientUnswapped,
     address payable _recipientSwapped
-  ) external returns (uint256 _unswapped, uint256 _swapped) {
-    if (!permissionManager.hasPermission(_positionId, msg.sender, IDCAPermissionManager.Permission.TERMINATE))
-      revert IDCAHubCompanion.UnauthorizedCaller();
+  ) external checkPermission(_positionId, IDCAPermissionManager.Permission.TERMINATE) returns (uint256 _unswapped, uint256 _swapped) {
     (_unswapped, _swapped) = hub.terminate(_positionId, _recipientUnswapped, address(this));
     _unwrapAndSend(_swapped, _recipientSwapped);
   }

--- a/contracts/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
@@ -30,7 +30,9 @@ abstract contract DCAHubCompanionWTokenPositionHandler is DCAHubCompanionParamet
       _convertedFrom = address(wToken);
     } else {
       IERC20(_from).safeTransferFrom(msg.sender, address(this), _amount);
-      IERC20(_from).approve(address(hub), _amount);
+      // If the token we are going to approve doesn't have the approval issue we see in USDT, we will approve 1 extra.
+      // We are doing that so that the allowance isn't fully spent, and the next approve is cheaper.
+      IERC20(_from).approve(address(hub), tokenHasApprovalIssue[_from] ? _amount : _amount + 1);
       _convertedTo = address(wToken);
     }
 

--- a/contracts/interfaces/IDCAHubCompanion.sol
+++ b/contracts/interfaces/IDCAHubCompanion.sol
@@ -10,6 +10,14 @@ import './utils/IGovernable.sol';
 import './ISharedTypes.sol';
 
 interface IDCAHubCompanionParameters is IGovernable {
+  /// @notice Thrown when the given parameters are invalid
+  error InvalidTokenApprovalParams();
+
+  /// @notice Emitted when tokens with approval issues are set
+  /// @param addresses The addresses of the tokens
+  /// @param hasIssue Whether they have issues or not
+  event TokenWithApprovalIssuesSet(address[] addresses, bool[] hasIssue);
+
   /// @notice Returns the DCA Hub's address
   /// @dev This value cannot be modified
   /// @return The DCA Hub contract
@@ -29,6 +37,17 @@ interface IDCAHubCompanionParameters is IGovernable {
   /// @notice Returns the permission manager contract
   /// @return The contract itself
   function permissionManager() external view returns (IDCAPermissionManager);
+
+  /// @notice Returns whether the given address has issues with approvals, like USDT
+  /// @param _tokenAddress The address of the token to check
+  /// @return Whether it has issues or not
+  function tokenHasApprovalIssue(address _tokenAddress) external view returns (bool);
+
+  /// @notice Sets whether specific addresses have issues with approvals, like USDT
+  /// @dev Will revert with `InvalidTokenApprovalParams` if the length of the given arrays differ
+  /// @param _addresses The addresses of the tokens
+  /// @param _hasIssue Wether they have issues or not
+  function setTokensWithApprovalIssues(address[] calldata _addresses, bool[] calldata _hasIssue) external;
 }
 
 interface IDCAHubCompanionSwapHandler is IDCAHubSwapCallee {

--- a/contracts/mocks/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
+++ b/contracts/mocks/DCAHubCompanion/DCAHubCompanionMulticallHandler.sol
@@ -5,7 +5,9 @@ import '../../DCAHubCompanion/DCAHubCompanionMulticallHandler.sol';
 import './DCAHubCompanionParameters.sol';
 
 contract DCAHubCompanionMulticallHandlerMock is DCAHubCompanionMulticallHandler, DCAHubCompanionParametersMock {
-  constructor(IDCAHub _hub, IDCAPermissionManager _permissionManager)
-    DCAHubCompanionParametersMock(_hub, _permissionManager, IWrappedProtocolToken(address(1)), address(1))
-  {}
+  constructor(
+    IDCAHub _hub,
+    IDCAPermissionManager _permissionManager,
+    address _governor
+  ) DCAHubCompanionParametersMock(_hub, _permissionManager, IWrappedProtocolToken(address(1)), _governor) {}
 }

--- a/contracts/mocks/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
+++ b/contracts/mocks/DCAHubCompanion/DCAHubCompanionWTokenPositionHandler.sol
@@ -8,6 +8,7 @@ contract DCAHubCompanionWTokenPositionHandlerMock is DCAHubCompanionWTokenPositi
   constructor(
     IDCAHub _hub,
     IDCAPermissionManager _permissionManager,
-    IWrappedProtocolToken _wToken
-  ) DCAHubCompanionParametersMock(_hub, _permissionManager, _wToken, address(1)) {}
+    IWrappedProtocolToken _wToken,
+    address _governor
+  ) DCAHubCompanionParametersMock(_hub, _permissionManager, _wToken, _governor) {}
 }


### PR DESCRIPTION
We are now adding support for tokens like USDT, that don't allow us to approve a new amount of tokens if the allowance is already more than zero.