### PR TITLE
refactor: keep3r job no longer needs swapper to be set in deployment

### DIFF
--- a/contracts/DCAKeep3rJob/DCAKeep3rJob.sol
+++ b/contracts/DCAKeep3rJob/DCAKeep3rJob.sol
@@ -13,13 +13,8 @@ contract DCAKeep3rJob is Governable, IDCAKeep3rJob {
   address public swapper;
   mapping(address => bool) public canAddressSignWork;
 
-  constructor(
-    address _swapper,
-    IKeep3rJobs _keep3r,
-    address _governor
-  ) Governable(_governor) {
-    if (address(_swapper) == address(0) || address(_keep3r) == address(0)) revert ZeroAddress();
-    swapper = _swapper;
+  constructor(IKeep3rJobs _keep3r, address _governor) Governable(_governor) {
+    if (address(_keep3r) == address(0)) revert ZeroAddress();
     keep3r = _keep3r;
   }
 

--- a/contracts/DCAKeep3rJob/DCAKeep3rJob.sol
+++ b/contracts/DCAKeep3rJob/DCAKeep3rJob.sol
@@ -13,8 +13,13 @@ contract DCAKeep3rJob is Governable, IDCAKeep3rJob {
   address public swapper;
   mapping(address => bool) public canAddressSignWork;
 
-  constructor(IKeep3rJobs _keep3r, address _governor) Governable(_governor) {
+  constructor(
+    address _swapper,
+    IKeep3rJobs _keep3r,
+    address _governor
+  ) Governable(_governor) {
     if (address(_keep3r) == address(0)) revert ZeroAddress();
+    if (address(_swapper) != address(0)) swapper = _swapper;
     keep3r = _keep3r;
   }
 

--- a/contracts/mocks/DCAKeep3rJob/DCAKeep3rJob.sol
+++ b/contracts/mocks/DCAKeep3rJob/DCAKeep3rJob.sol
@@ -6,11 +6,7 @@ import '../../DCAKeep3rJob/DCAKeep3rJob.sol';
 contract DCAKeep3rJobMock is DCAKeep3rJob {
   bytes public swapperCalledWith;
 
-  constructor(
-    address _swapper,
-    IKeep3rJobs _keep3r,
-    address _governor
-  ) DCAKeep3rJob(_swapper, _keep3r, _governor) {}
+  constructor(IKeep3rJobs _keep3r, address _governor) DCAKeep3rJob(_keep3r, _governor) {}
 
   function _callSwapper(bytes memory _data) internal override {
     swapperCalledWith = _data;

--- a/contracts/mocks/DCAKeep3rJob/DCAKeep3rJob.sol
+++ b/contracts/mocks/DCAKeep3rJob/DCAKeep3rJob.sol
@@ -6,7 +6,11 @@ import '../../DCAKeep3rJob/DCAKeep3rJob.sol';
 contract DCAKeep3rJobMock is DCAKeep3rJob {
   bytes public swapperCalledWith;
 
-  constructor(IKeep3rJobs _keep3r, address _governor) DCAKeep3rJob(_keep3r, _governor) {}
+  constructor(
+    address _swapper,
+    IKeep3rJobs _keep3r,
+    address _governor
+  ) DCAKeep3rJob(_swapper, _keep3r, _governor) {}
 
   function _callSwapper(bytes memory _data) internal override {
     swapperCalledWith = _data;

--- a/deploy/003_keep3r_job.ts
+++ b/deploy/003_keep3r_job.ts
@@ -20,12 +20,16 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
 
   const companion = await hre.deployments.getOrNull('DCAHubCompanion');
 
-  await hre.deployments.deploy('DCAKeep3rJob', {
-    contract: 'contracts/DCAKeep3rJob/DCAKeep3rJob.sol:DCAKeep3rJob',
-    from: deployer,
-    args: [!!companion ? companion.address : constants.ZERO_ADDRESS, keep3r, governor],
-    log: true,
-  });
+  const keep3rJob = await hre.deployments.getOrNull('DCAKeep3rJob');
+
+  if (!keep3rJob) {
+    await hre.deployments.deploy('DCAKeep3rJob', {
+      contract: 'contracts/DCAKeep3rJob/DCAKeep3rJob.sol:DCAKeep3rJob',
+      from: deployer,
+      args: [!!companion ? companion.address : constants.ZERO_ADDRESS, keep3r, governor],
+      log: true,
+    });
+  }
 };
 
 deployFunction.tags = ['DCAKeep3rJob'];

--- a/deploy/003_keep3r_job.ts
+++ b/deploy/003_keep3r_job.ts
@@ -17,15 +17,13 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
       return;
   }
 
-  const companion = await hre.deployments.get('DCAHubCompanion');
   await hre.deployments.deploy('DCAKeep3rJob', {
     contract: 'contracts/DCAKeep3rJob/DCAKeep3rJob.sol:DCAKeep3rJob',
     from: deployer,
-    args: [companion.address, keep3r, governor],
+    args: [keep3r, governor],
     log: true,
   });
 };
 
-deployFunction.dependencies = ['DCAHubCompanion'];
 deployFunction.tags = ['DCAKeep3rJob'];
 export default deployFunction;

--- a/deploy/003_keep3r_job.ts
+++ b/deploy/003_keep3r_job.ts
@@ -1,6 +1,7 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from 'hardhat-deploy/types';
 import { networkBeingForked } from '@test-utils/evm';
+import { constants } from '@test-utils';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, governor } = await hre.getNamedAccounts();
@@ -17,10 +18,12 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
       return;
   }
 
+  const companion = await hre.deployments.getOrNull('DCAHubCompanion');
+
   await hre.deployments.deploy('DCAKeep3rJob', {
     contract: 'contracts/DCAKeep3rJob/DCAKeep3rJob.sol:DCAKeep3rJob',
     from: deployer,
-    args: [keep3r, governor],
+    args: [!!companion ? companion.address : constants.ZERO_ADDRESS, keep3r, governor],
     log: true,
   });
 };

--- a/test/integration/DCAKeep3rJob/keep3r-job.spec.ts
+++ b/test/integration/DCAKeep3rJob/keep3r-job.spec.ts
@@ -41,7 +41,7 @@ contract('DCAKeep3rJob', () => {
       network: 'mainnet',
     });
 
-    await deployments.fixture('DCAKeep3rJob', { keepExistingDeployments: false });
+    await deployments.fixture(['DCAHubCompanion', 'DCAKeep3rJob'], { keepExistingDeployments: false });
 
     DCAHub = await ethers.getContract('DCAHub');
     DCAHubCompanion = await ethers.getContract('DCAHubCompanion');
@@ -59,6 +59,8 @@ contract('DCAKeep3rJob', () => {
     const k3prWhale = await wallet.impersonate(K3PR_WHALE_ADDRESS);
     await ethers.provider.send('hardhat_setBalance', [K3PR_WHALE_ADDRESS, '0xffffffffffffffff']);
 
+    // Set companion as swapper
+    await DCAKeep3rJob.connect(governor).setSwapper(DCAHubCompanion.address);
     // Allow one minute interval
     await DCAHub.connect(governor).addSwapIntervalsToAllowedList([SwapInterval.ONE_MINUTE.seconds]);
     // Allow signer to sign work

--- a/test/integration/DCAKeep3rJob/keep3r-job.spec.ts
+++ b/test/integration/DCAKeep3rJob/keep3r-job.spec.ts
@@ -60,7 +60,7 @@ contract('DCAKeep3rJob', () => {
     await ethers.provider.send('hardhat_setBalance', [K3PR_WHALE_ADDRESS, '0xffffffffffffffff']);
 
     // Set companion as swapper
-    await DCAKeep3rJob.connect(governor).setSwapper(DCAHubCompanion.address);
+    // await DCAKeep3rJob.connect(governor).setSwapper(DCAHubCompanion.address);
     // Allow one minute interval
     await DCAHub.connect(governor).addSwapIntervalsToAllowedList([SwapInterval.ONE_MINUTE.seconds]);
     // Allow signer to sign work

--- a/test/integration/DCAKeep3rJob/keep3r-job.spec.ts
+++ b/test/integration/DCAKeep3rJob/keep3r-job.spec.ts
@@ -59,8 +59,6 @@ contract('DCAKeep3rJob', () => {
     const k3prWhale = await wallet.impersonate(K3PR_WHALE_ADDRESS);
     await ethers.provider.send('hardhat_setBalance', [K3PR_WHALE_ADDRESS, '0xffffffffffffffff']);
 
-    // Set companion as swapper
-    // await DCAKeep3rJob.connect(governor).setSwapper(DCAHubCompanion.address);
     // Allow one minute interval
     await DCAHub.connect(governor).addSwapIntervalsToAllowedList([SwapInterval.ONE_MINUTE.seconds]);
     // Allow signer to sign work

--- a/test/unit/DCAKeep3rJob/dca-keep3r-job.spec.ts
+++ b/test/unit/DCAKeep3rJob/dca-keep3r-job.spec.ts
@@ -38,12 +38,9 @@ contract('DCAKeep3rJob', () => {
 
   describe('constructor', () => {
     when('swapper is zero address', () => {
-      then('deployment is reverted with reason', async () => {
-        await behaviours.deployShouldRevertWithMessage({
-          contract: DCAKeep3rJobFactory,
-          args: [constants.ZERO_ADDRESS, keep3r.address, governor.address],
-          message: 'ZeroAddress',
-        });
+      then('deployment should not revert', async () => {
+        const deploymentTx = DCAKeep3rJobFactory.getDeployTransaction(constants.ZERO_ADDRESS, keep3r.address, governor.address);
+        await expect(DCAKeep3rJobFactory.signer.sendTransaction(deploymentTx)).to.not.be.reverted;
       });
     });
     when('keep3r is zero address', () => {


### PR DESCRIPTION
In order to be able to deploy the keep3r job and start acquiring keep3r credits through `V2` we need to deploy the keep3r job alone. This PR solves that.