### PR TITLE
feat: add access management

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import '@openzeppelin/contracts/utils/Multicall.sol';
 import '../interfaces/IDCAFeeManager.sol';
 import '../utils/Governable.sol';
 
-contract DCAFeeManager is Governable, IDCAFeeManager {
+contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
+  using SafeERC20 for IERC20;
+
   /// @inheritdoc IDCAFeeManager
   uint16 public constant MAX_TOKEN_TOTAL_SHARE = 10000;
   /// @inheritdoc IDCAFeeManager
@@ -12,22 +17,104 @@ contract DCAFeeManager is Governable, IDCAFeeManager {
   /// @inheritdoc IDCAFeeManager
   IDCAHub public immutable hub;
   /// @inheritdoc IDCAFeeManager
+  IWrappedProtocolToken public immutable wToken;
+  /// @inheritdoc IDCAFeeManager
   mapping(address => bool) public hasAccess;
+  /// @inheritdoc IDCAFeeManager
+  mapping(bytes32 => uint256) public positions; // key(from, to) => position id
 
-  TargetTokenShare[] internal _distribution;
+  mapping(address => uint256[]) internal _positionsWithToken; // token address => all positions with address as to
 
   constructor(
     IDCAHub _hub,
-    TargetTokenShare[] memory _distributionToSet,
+    IWrappedProtocolToken _wToken,
     address _governor
   ) Governable(_governor) {
     hub = _hub;
-    _setTargetTokensDistribution(_distributionToSet);
+    wToken = _wToken;
   }
 
   /// @inheritdoc IDCAFeeManager
-  function targetTokensDistribution() external view returns (TargetTokenShare[] memory) {
-    return _distribution;
+  function withdrawProtocolToken(
+    bool _withdrawFromPlatform,
+    uint256[] calldata _positionIds,
+    address payable _recipient
+  ) external onlyOwnerOrAllowed {
+    // Withdraw wToken from platform balance
+    if (_withdrawFromPlatform) {
+      uint256 _platformBalance = hub.platformBalance(address(wToken));
+      if (_platformBalance > 0) {
+        IDCAHub.AmountOfToken[] memory _amountToWithdraw = new IDCAHub.AmountOfToken[](1);
+        _amountToWithdraw[0] = IDCAHub.AmountOfToken({token: address(wToken), amount: _platformBalance});
+        hub.withdrawFromPlatformBalance(_amountToWithdraw, address(this));
+      }
+    }
+
+    // Withdraw wToken from positions
+    if (_positionIds.length > 0) {
+      IDCAHub.PositionSet[] memory _positionSets = new IDCAHub.PositionSet[](1);
+      _positionSets[0] = IDCAHubPositionHandler.PositionSet({token: address(wToken), positionIds: _positionIds});
+      hub.withdrawSwappedMany(_positionSets, address(this));
+    }
+
+    // Unwrap and transfer
+    uint256 _totalBalance = wToken.balanceOf(address(this));
+    if (_totalBalance > 0) {
+      wToken.withdraw(_totalBalance);
+      _recipient.transfer(_totalBalance);
+    }
+  }
+
+  /// @inheritdoc IDCAFeeManager
+  function withdrawFromPlatformBalance(IDCAHub.AmountOfToken[] calldata _amountToWithdraw, address _recipient) external onlyOwnerOrAllowed {
+    hub.withdrawFromPlatformBalance(_amountToWithdraw, _recipient);
+  }
+
+  /// @inheritdoc IDCAFeeManager
+  function withdrawFromBalance(IDCAHub.AmountOfToken[] calldata _amountToWithdraw, address _recipient) external onlyOwnerOrAllowed {
+    for (uint256 i; i < _amountToWithdraw.length; i++) {
+      IERC20(_amountToWithdraw[i].token).safeTransfer(_recipient, _amountToWithdraw[i].amount);
+    }
+  }
+
+  /// @inheritdoc IDCAFeeManager
+  function withdrawFromPositions(IDCAHub.PositionSet[] calldata _positionSets, address _recipient) external onlyOwnerOrAllowed {
+    hub.withdrawSwappedMany(_positionSets, _recipient);
+  }
+
+  /// @inheritdoc IDCAFeeManager
+  function fillPositions(AmountToFill[] calldata _amounts, TargetTokenShare[] calldata _distribution) external onlyOwnerOrAllowed {
+    for (uint256 i; i < _amounts.length; i++) {
+      AmountToFill memory _amount = _amounts[i];
+
+      if (IERC20(_amount.token).allowance(address(this), address(hub)) == 0) {
+        // Approve the token so that the hub can take the funds
+        IERC20(_amount.token).approve(address(hub), type(uint256).max);
+      }
+
+      // Distribute to different tokens
+      uint256 _amountSpent;
+      for (uint256 j; j < _distribution.length; j++) {
+        uint256 _amountToDeposit = j < _distribution.length - 1
+          ? (_amount.amount * _distribution[j].shares) / MAX_TOKEN_TOTAL_SHARE
+          : _amount.amount - _amountSpent; // If this is the last token, then assign everything that hasn't been spent. We do this to prevent unspent tokens due to rounding errors
+
+        bool _failed = _depositToHub(_amount.token, _distribution[j].token, _amountToDeposit, _amount.amountOfSwaps);
+        if (!_failed) {
+          _amountSpent += _amountToDeposit;
+        }
+      }
+    }
+  }
+
+  /// @inheritdoc IDCAFeeManager
+  function terminatePositions(uint256[] calldata _positionIds, address _recipient) external onlyOwnerOrAllowed {
+    for (uint256 i; i < _positionIds.length; i++) {
+      uint256 _positionId = _positionIds[i];
+      IDCAHubPositionHandler.UserPosition memory _position = hub.userPosition(_positionId);
+      hub.terminate(_positionId, _recipient, _recipient);
+      delete positions[getPositionKey(address(_position.from), address(_position.to))];
+    }
   }
 
   /// @inheritdoc IDCAFeeManager
@@ -39,40 +126,76 @@ contract DCAFeeManager is Governable, IDCAFeeManager {
   }
 
   /// @inheritdoc IDCAFeeManager
-  function setTargetTokensDistribution(TargetTokenShare[] calldata _newDistribution) external onlyOwnerOrAllowed {
-    _setTargetTokensDistribution(_newDistribution);
+  function resetAllowance(IERC20 _token) external {
+    _token.approve(address(hub), 0); // We do this first because some tokens (like USDT) will fail if we  don't
+    _token.approve(address(hub), type(uint256).max);
   }
 
-  function _setTargetTokensDistribution(TargetTokenShare[] memory _newDistribution) internal {
-    uint256 _currentTargetTokens = _distribution.length;
-    uint256 _min = _currentTargetTokens < _newDistribution.length ? _currentTargetTokens : _newDistribution.length;
-
-    uint16 _assignedShares;
-    for (uint256 i; i < _min; i++) {
-      // Rewrite storage
-      _assignedShares += _newDistribution[i].shares;
-      _distribution[i] = _newDistribution[i];
-    }
-
-    if (_currentTargetTokens < _newDistribution.length) {
-      // If have more tokens than before, then push
-      for (uint256 i = _min; i < _newDistribution.length; i++) {
-        _assignedShares += _newDistribution[i].shares;
-        _distribution.push(_newDistribution[i]);
+  /// @inheritdoc IDCAFeeManager
+  function availableBalances(address[] calldata _tokens) external view returns (AvailableBalance[] memory _balances) {
+    _balances = new AvailableBalance[](_tokens.length);
+    for (uint256 i; i < _tokens.length; i++) {
+      address _token = _tokens[i];
+      uint256[] memory _positionIds = _positionsWithToken[_token];
+      PositionBalance[] memory _positions = new PositionBalance[](_positionIds.length);
+      for (uint256 j; j < _positionIds.length; j++) {
+        IDCAHubPositionHandler.UserPosition memory _userPosition = hub.userPosition(_positionIds[j]);
+        _positions[j] = PositionBalance({
+          positionId: _positionIds[j],
+          from: _userPosition.from,
+          to: _userPosition.to,
+          swapped: _userPosition.swapped,
+          remaining: _userPosition.remaining
+        });
       }
-    } else if (_currentTargetTokens > _newDistribution.length) {
-      // If have less tokens than before, then remove extra tokens
-      for (uint256 i = _min; i < _currentTargetTokens; i++) {
-        _distribution.pop();
+      _balances[i] = AvailableBalance({
+        token: _token,
+        platformBalance: hub.platformBalance(_token),
+        feeManagerBalance: IERC20(_token).balanceOf(address(this)),
+        positions: _positions
+      });
+    }
+  }
+
+  function getPositionKey(address _from, address _to) public pure returns (bytes32) {
+    return keccak256(abi.encodePacked(_from, _to));
+  }
+
+  receive() external payable {}
+
+  function _depositToHub(
+    address _from,
+    address _to,
+    uint256 _amount,
+    uint32 _amountOfSwaps
+  ) internal returns (bool _failed) {
+    // We will try to create or increase an existing position, but both could fail. Maybe one of the tokens is no longer
+    // allowed, or a pair not supported, so we need to check if it fails or not and act accordingly
+
+    // Find the position for this token
+    bytes32 _key = getPositionKey(_from, _to);
+    uint256 _positionId = positions[_key];
+
+    if (_positionId == 0) {
+      // If position doesn't exist, then try to create it
+      try hub.deposit(_from, _to, _amount, _amountOfSwaps, SWAP_INTERVAL, address(this), new IDCAPermissionManager.PermissionSet[](0)) returns (
+        uint256 _newPositionId
+      ) {
+        positions[_key] = _newPositionId;
+        _positionsWithToken[_to].push(_newPositionId);
+      } catch {
+        _failed = true;
+      }
+    } else {
+      // If position exists, then try to increase it
+      try hub.increasePosition(_positionId, _amount, _amountOfSwaps) {} catch {
+        _failed = true;
       }
     }
-
-    if (_assignedShares != MAX_TOKEN_TOTAL_SHARE) revert InvalidAmountOfShares();
-    emit NewDistribution(_newDistribution);
   }
 
   modifier onlyOwnerOrAllowed() {
-    if (!isGovernor(msg.sender) && !hasAccess[msg.sender]) revert CallerMustBeOwnerOrHaveAccess();
+    if (!hasAccess[msg.sender] && !isGovernor(msg.sender)) revert CallerMustBeOwnerOrHaveAccess();
     _;
   }
 }

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -19,6 +19,15 @@ interface IDCAFeeManager is IGovernable {
     uint16 shares;
   }
 
+  /// @notice Represents a user and the new access that should be assigned to them
+  struct UserAccess {
+    address user;
+    bool access;
+  }
+
+  /// @notice Thrown when a user tries to execute a permissioned action without the access to do so
+  error CallerMustBeOwnerOrHaveAccess();
+
   /// @notice Thrown when a user tries to set an invalid distribution
   error InvalidAmountOfShares();
 
@@ -27,6 +36,12 @@ interface IDCAFeeManager is IGovernable {
    * @param distribution The new distribution
    */
   event NewDistribution(TargetTokenShare[] distribution);
+
+  /**
+   * @notice Emitted when access is modified for some users
+   * @param access The modified users and their new access
+   */
+  event NewAccess(UserAccess[] access);
 
   /**
    * @notice The contract's owner and other allowed users can specify the target tokens that the fees
@@ -58,6 +73,21 @@ interface IDCAFeeManager is IGovernable {
    * @return The distribution for the target tokens
    */
   function targetTokensDistribution() external view returns (TargetTokenShare[] memory);
+
+  /**
+   * @notice Returns whether the given user has access to set the target tokens distribution or
+   *         execute withdraws
+   * @param user The user to check access for
+   * @return Whether the given user has access
+   */
+  function hasAccess(address user) external view returns (bool);
+
+  /**
+   * @notice Gives or takes access to permissioned actions from users
+   * @dev Only the contract owner can execute this action
+   * @param access The users to affect, and how to affect them
+   */
+  function setAccess(UserAccess[] calldata access) external;
 
   /**
    * @notice Sets the distribution for the target tokens

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -25,17 +25,32 @@ interface IDCAFeeManager is IGovernable {
     bool access;
   }
 
+  /// @notice Represents how much to deposit to a position, for a specific token
+  struct AmountToFill {
+    address token;
+    uint32 amountOfSwaps;
+    uint256 amount;
+  }
+
+  /// @notice Represents how much is available for withdraw, for a specific token
+  struct AvailableBalance {
+    address token;
+    uint256 platformBalance;
+    uint256 feeManagerBalance;
+    PositionBalance[] positions;
+  }
+
+  /// @notice Represents information about a specific position
+  struct PositionBalance {
+    uint256 positionId;
+    IERC20Metadata from;
+    IERC20Metadata to;
+    uint256 swapped;
+    uint256 remaining;
+  }
+
   /// @notice Thrown when a user tries to execute a permissioned action without the access to do so
   error CallerMustBeOwnerOrHaveAccess();
-
-  /// @notice Thrown when a user tries to set an invalid distribution
-  error InvalidAmountOfShares();
-
-  /**
-   * @notice Emitted when a new distribution is set
-   * @param distribution The new distribution
-   */
-  event NewDistribution(TargetTokenShare[] distribution);
 
   /**
    * @notice Emitted when access is modified for some users
@@ -68,19 +83,84 @@ interface IDCAFeeManager is IGovernable {
   function hub() external view returns (IDCAHub);
 
   /**
-   * @notice Returns the distribution for the target tokens. Target tokens are the tokens that we
-   *         want to swap the fees to. We can assign a distribution to convert to many different tokens
-   * @return The distribution for the target tokens
+   * @notice Returns address for the wToken
+   * @dev This value cannot be modified after deployment
+   * @return The address for the wToken
    */
-  function targetTokensDistribution() external view returns (TargetTokenShare[] memory);
+  function wToken() external view returns (IWrappedProtocolToken);
 
   /**
-   * @notice Returns whether the given user has access to set the target tokens distribution or
-   *         execute withdraws
+   * @notice Returns whether the given user has access to fill positions or execute withdraws
    * @param user The user to check access for
    * @return Whether the given user has access
    */
   function hasAccess(address user) external view returns (bool);
+
+  /**
+   * @notice Returns the position id for a given (from, to) pair
+   * @dev Key for (tokenA, tokenB) is different from the key for(tokenB, tokenA)
+   * @param pairKey The key of the pair (from, to)
+   * @return The position id for the given pair
+   */
+  function positions(bytes32 pairKey) external view returns (uint256); // key(from, to) => position id
+
+  /**
+   * @notice Withdraws all wToken balance from the platform balance and the given positions,
+   *         unwraps it in exchange for the protocol token, and sends it to the given recipient
+   * @dev Can only be executed by the owner or allowed users
+   * @param withdrawFromPlatform Specify if we want to withdraw from the platform balance or not
+   * @param positionIds The ids of the positions that we want to withdraw wToken from. These positions
+   *                    have swapped other tokens in exchange for wToken
+   * @param recipient The address of the recipient, that will receive all the protocol token balance
+   */
+  function withdrawProtocolToken(
+    bool withdrawFromPlatform,
+    uint256[] calldata positionIds,
+    address payable recipient
+  ) external;
+
+  /**
+   * @notice Withdraws tokens from the platform balance, and sends them to the given recipient
+   * @dev Can only be executed by the owner or allowed users
+   * @param amountToWithdraw The tokens to withdraw, and their amounts
+   * @param recipient The address of the recipient
+   */
+  function withdrawFromPlatformBalance(IDCAHub.AmountOfToken[] calldata amountToWithdraw, address recipient) external;
+
+  /**
+   * @notice Withdraws tokens from the contract's balance, and sends them to the given recipient
+   * @dev Can only be executed by the owner or allowed users
+   * @param amountToWithdraw The tokens to withdraw, and their amounts
+   * @param recipient The address of the recipient
+   */
+  function withdrawFromBalance(IDCAHub.AmountOfToken[] calldata amountToWithdraw, address recipient) external;
+
+  /**
+   * @notice Withdraws tokens from the given positions, and sends them to the given recipient
+   * @dev Can only be executed by the owner or allowed users
+   * @param positionSets The positions to withdraw from
+   * @param recipient The address of the recipient
+   */
+  function withdrawFromPositions(IDCAHub.PositionSet[] calldata positionSets, address recipient) external;
+
+  /**
+   * @notice Takes a certain amount of the given tokens, and sets up DCA swaps for each of them.
+   *         The given amounts can be distributed across different target tokens
+   * @dev Can only be executed by the owner or allowed users
+   * @param amounts Specific tokens and amounts to take from this contract and send to the hub
+   * @param distribution How to distribute the source tokens across different target tokens
+   */
+  function fillPositions(AmountToFill[] calldata amounts, TargetTokenShare[] calldata distribution) external;
+
+  /**
+   * @notice Takes list of position ids and terminates them. All swapped and unswapped balance is
+   *         sent to the given recipient. This is meant to be used only if for some reason swaps are
+   *         no longer executed
+   * @dev Can only be executed by the owner or allowed users
+   * @param positionIds The positions to terminate
+   * @param recipient The address that will receive all swapped and unswapped tokens
+   */
+  function terminatePositions(uint256[] calldata positionIds, address recipient) external;
 
   /**
    * @notice Gives or takes access to permissioned actions from users
@@ -90,9 +170,16 @@ interface IDCAFeeManager is IGovernable {
   function setAccess(UserAccess[] calldata access) external;
 
   /**
-   * @notice Sets the distribution for the target tokens
-   * @dev Can only be set by the owner or allowed users
-   * @param distribution The new distribution to set
+   * @notice Sets the maximum allowance to the DCA Hub, for the given token
+   * @param token The token to set the allowance for
    */
-  function setTargetTokensDistribution(TargetTokenShare[] calldata distribution) external;
+  function resetAllowance(IERC20 token) external;
+
+  /**
+   * @notice Returns how much is available for withdraw, for the given tokens
+   * @dev This is meant for off-chan purposes
+   * @param tokens The tokens to check the balance for
+   * @return How much is available for withdraw, for the given tokens
+   */
+  function availableBalances(address[] calldata tokens) external view returns (AvailableBalance[] memory);
 }

--- a/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../../DCAFeeManager/DCAFeeManager.sol';
+
+contract DCAFeeManagerMock is DCAFeeManager {
+  constructor(
+    IDCAHub _hub,
+    IWrappedProtocolToken _wToken,
+    address _governor
+  ) DCAFeeManager(_hub, _wToken, _governor) {}
+
+  function setPosition(
+    address _from,
+    address _to,
+    uint256 _positionId
+  ) external {
+    positions[getPositionKey(_from, _to)] = _positionId;
+  }
+
+  function positionsWithToken(address _toToken) external view returns (uint256[] memory) {
+    return _positionsWithToken[_toToken];
+  }
+
+  function setPositionsWithToken(address _toToken, uint256[] calldata _positionIds) external {
+    for (uint256 i; i < _positionIds.length; i++) {
+      _positionsWithToken[_toToken].push(_positionIds[i]);
+    }
+  }
+}

--- a/deploy/005_fee_manager.ts
+++ b/deploy/005_fee_manager.ts
@@ -1,0 +1,43 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from '@0xged/hardhat-deploy/types';
+import { networkBeingForked } from '@test-utils/evm';
+
+const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployer, governor } = await hre.getNamedAccounts();
+
+  let wProtocolToken: string;
+  const network = hre.network.name !== 'hardhat' ? hre.network.name : networkBeingForked ?? hre.network.name;
+  switch (network) {
+    case 'hardhat':
+    case 'mainnet':
+      wProtocolToken = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // WETH
+      break;
+    case 'kovan':
+      wProtocolToken = '0xd0a1e359811322d97991e03f863a0c30c2cf029c'; // WETH
+      break;
+    case 'optimism-kovan':
+    case 'optimism':
+      wProtocolToken = '0x4200000000000000000000000000000000000006'; // WETH
+      break;
+    case 'mumbai':
+      wProtocolToken = '0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889'; // WMATIC
+      break;
+    case 'polygon':
+      wProtocolToken = '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'; // WMATIC
+      break;
+    default:
+      throw new Error(`Unsupported chain '${hre.network.name}`);
+  }
+
+  const hub = await hre.deployments.get('DCAHub');
+
+  await hre.deployments.deploy('DCAFeeManager', {
+    contract: 'contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager',
+    from: deployer,
+    args: [hub.address, wProtocolToken, governor],
+    log: true,
+  });
+};
+
+deployFunction.tags = ['DCAFeeManager'];
+export default deployFunction;

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -1,0 +1,178 @@
+import { expect } from 'chai';
+import { deployments, ethers, getNamedAccounts } from 'hardhat';
+import { JsonRpcSigner } from '@ethersproject/providers';
+import { constants, wallet } from '@test-utils';
+import { contract } from '@test-utils/bdd';
+import evm from '@test-utils/evm';
+import { DCAHubSwapper, IERC20, DCAFeeManager } from '@typechained';
+import { DCAHub } from '@mean-finance/dca-v2-core/typechained';
+import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
+import { BigNumber, utils } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { SwapInterval } from '@test-utils/interval-utils';
+import forkBlockNumber from '@integration/fork-block-numbers';
+import { DeterministicFactory, DeterministicFactory__factory } from '@mean-finance/deterministic-factory/typechained';
+import { buildSwapInput } from '@test-utils/swap-utils';
+
+const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const WBTC_ADDRESS = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599';
+const WETH_WHALE_ADDRESS = '0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e';
+const USDC_WHALE_ADDRESS = '0xcffad3200574698b78f32232aa9d63eabd290703';
+const WBTC_WHALE_ADDRESS = '0x9ff58f4ffb29fa2266ab25e75e2a8b3503311656';
+
+contract('DCAFeeManager', () => {
+  const RECIPIENT = wallet.generateRandomAddress();
+  let WETH: IERC20, USDC: IERC20, WBTC: IERC20;
+  let governor: JsonRpcSigner;
+  let cindy: SignerWithAddress, allowed: SignerWithAddress, swapper: SignerWithAddress;
+  let DCAFeeManager: DCAFeeManager;
+  let DCAHubSwapper: DCAHubSwapper;
+  let DCAHub: DCAHub;
+
+  before(async () => {
+    await evm.reset({
+      network: 'mainnet',
+      blockNumber: forkBlockNumber['swap-for-caller'],
+      skipHardhatDeployFork: true,
+    });
+    [cindy, allowed, swapper] = await ethers.getSigners();
+
+    const namedAccounts = await getNamedAccounts();
+    const governorAddress = namedAccounts.governor;
+    governor = await wallet.impersonate(governorAddress);
+    await ethers.provider.send('hardhat_setBalance', [governorAddress, '0xffffffffffffffff']);
+
+    const deterministicFactory = await ethers.getContractAt<DeterministicFactory>(
+      DeterministicFactory__factory.abi,
+      '0xbb681d77506df5CA21D2214ab3923b4C056aa3e2'
+    );
+
+    await deterministicFactory.connect(governor).grantRole(await deterministicFactory.DEPLOYER_ROLE(), namedAccounts.deployer);
+
+    await deployments.run(['DCAHub', 'DCAHubSwapper', 'DCAFeeManager'], {
+      resetMemory: true,
+      deletePreviousDeployments: false,
+      writeDeploymentsToFiles: false,
+    });
+
+    DCAHub = await ethers.getContract('DCAHub');
+    DCAHubSwapper = await ethers.getContract('DCAHubSwapper');
+    DCAFeeManager = await ethers.getContract('DCAFeeManager');
+
+    // Set up tokens and permissions
+    await DCAHub.connect(governor).setAllowedTokens([WETH_ADDRESS, USDC_ADDRESS, WBTC_ADDRESS], [true, true, true]);
+    await DCAHub.connect(governor).grantRole(await DCAHub.PLATFORM_WITHDRAW_ROLE(), DCAFeeManager.address);
+    await DCAFeeManager.connect(governor).setAccess([{ user: allowed.address, access: true }]);
+
+    WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
+    USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);
+    WBTC = await ethers.getContractAt(IERC20_ABI, WBTC_ADDRESS);
+
+    // Send tokens from whales, to our users
+    await distributeTokensToUsers();
+
+    // Handle approvals
+    await USDC.connect(swapper).approve(DCAHubSwapper.address, constants.MAX_UINT_256);
+    await WETH.connect(swapper).approve(DCAHubSwapper.address, constants.MAX_UINT_256);
+    await WBTC.connect(cindy).approve(DCAHub.address, constants.MAX_UINT_256);
+  });
+
+  it('swap, convert and withdraw as protocol token', async () => {
+    // Deposit
+    await DCAHub.connect(cindy)['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'](
+      WBTC.address,
+      USDC.address,
+      utils.parseUnits('0.1', 6),
+      1,
+      SwapInterval.ONE_DAY.seconds,
+      cindy.address,
+      []
+    );
+
+    // Execute swap
+    await swap({ from: WBTC, to: USDC });
+
+    // Calculate and verify balances
+    const [usdcBalance, wbtcBalance] = await DCAFeeManager.availableBalances([USDC.address, WBTC.address]);
+    expect(usdcBalance.platformBalance.gt(0)).to.be.true;
+    expect(usdcBalance.feeManagerBalance).to.equal(0);
+    expect(wbtcBalance.platformBalance).to.equal(0);
+    expect(wbtcBalance.feeManagerBalance.gt(0)).to.be.true;
+    expect(wbtcBalance.positions).to.have.lengthOf(0);
+
+    // Prepare data to withdraw USDC from platform balance
+    const { data: withdrawData } = await DCAFeeManager.populateTransaction.withdrawFromPlatformBalance(
+      [{ token: USDC.address, amount: usdcBalance.platformBalance }],
+      DCAFeeManager.address
+    );
+
+    // Prepare data to send WBTC and USDC to Hub, to DCA for WETH
+    const { data: fillData } = await DCAFeeManager.populateTransaction.fillPositions(
+      [
+        { token: USDC.address, amount: usdcBalance.platformBalance, amountOfSwaps: 1 },
+        { token: WBTC.address, amount: wbtcBalance.feeManagerBalance, amountOfSwaps: 1 },
+      ],
+      [{ token: WETH.address, shares: 10000 }]
+    );
+
+    // Execute withdraw + fill
+    await DCAFeeManager.connect(allowed).multicall([withdrawData!, fillData!]);
+
+    // Execute swap
+    await swap({ from: USDC, to: WETH }, { from: WBTC, to: WETH });
+
+    // Check balances
+    const [wethBalance] = await DCAFeeManager.availableBalances([WETH.address]);
+    expect(wethBalance.platformBalance.gt(0)).to.be.true;
+    expect(wethBalance.positions).to.have.lengthOf(2);
+    const [position1, position2] = wethBalance.positions;
+    expect(position1.from.toLowerCase()).to.equal(USDC.address.toLowerCase());
+    expect(position1.to.toLowerCase()).to.eql(WETH.address.toLowerCase());
+    expect(position1.swapped.gt(0)).to.be.true;
+    expect(position1.remaining).to.equal(0);
+    expect(position2.from.toLowerCase()).to.equal(WBTC.address.toLowerCase());
+    expect(position2.to.toLowerCase()).to.equal(WETH.address.toLowerCase());
+    expect(position2.swapped.gt(0)).to.be.true;
+    expect(position2.remaining).to.equal(0);
+
+    // Execute withdraw as protocol token
+    await DCAFeeManager.connect(allowed).withdrawProtocolToken(true, [position1.positionId, position2.positionId], RECIPIENT);
+
+    // Make sure that everything was transferred to recipient
+    const recipientBalance = await ethers.provider.getBalance(RECIPIENT);
+    const [wethBalanceAfter] = await DCAFeeManager.availableBalances([WETH.address]);
+    expect(wethBalanceAfter.platformBalance).to.equal(0);
+    const [position1After, position2After] = wethBalanceAfter.positions;
+    expect(recipientBalance).to.equal(wethBalance.platformBalance.add(position1.swapped).add(position2.swapped));
+    expect(position1After.swapped).to.equal(0);
+    expect(position2After.swapped).to.equal(0);
+  });
+
+  async function distributeTokensToUsers() {
+    const wethWhale = await wallet.impersonate(WETH_WHALE_ADDRESS);
+    const usdcWhale = await wallet.impersonate(USDC_WHALE_ADDRESS);
+    const wbtcWhale = await wallet.impersonate(WBTC_WHALE_ADDRESS);
+    await ethers.provider.send('hardhat_setBalance', [WBTC_WHALE_ADDRESS, '0xffffffffffffffff']);
+    await ethers.provider.send('hardhat_setBalance', [WETH_WHALE_ADDRESS, '0xffffffffffffffff']);
+    await ethers.provider.send('hardhat_setBalance', [USDC_WHALE_ADDRESS, '0xffffffffffffffff']);
+    await WBTC.connect(wbtcWhale).transfer(cindy.address, BigNumber.from(10).pow(12));
+    await WETH.connect(wethWhale).transfer(swapper.address, BigNumber.from(10).pow(22));
+    await USDC.connect(usdcWhale).transfer(swapper.address, BigNumber.from(10).pow(12));
+  }
+
+  async function swap(...pairs: { from: IERC20; to: IERC20 }[]) {
+    const { tokens, pairIndexes } = buildSwapInput(
+      pairs.map(({ from, to }) => ({ tokenA: from.address, tokenB: to.address })),
+      []
+    );
+    await DCAHubSwapper.connect(swapper).swapForCaller(
+      tokens,
+      pairIndexes,
+      tokens.map((_) => 0),
+      tokens.map((_) => constants.MAX_UINT_256),
+      DCAFeeManager.address,
+      constants.MAX_UINT_256
+    );
+  }
+});

--- a/test/integration/DCAHubSwapper/swap-for-caller.spec.ts
+++ b/test/integration/DCAHubSwapper/swap-for-caller.spec.ts
@@ -4,7 +4,7 @@ import { JsonRpcSigner, TransactionResponse } from '@ethersproject/providers';
 import { constants, wallet } from '@test-utils';
 import { contract, given, then, when } from '@test-utils/bdd';
 import evm, { snapshot } from '@test-utils/evm';
-import { DCAHubSwapper, DCAHubCompanion, IERC20 } from '@typechained';
+import { DCAHubSwapper, IERC20 } from '@typechained';
 import { DCAHub } from '@mean-finance/dca-v2-core/typechained';
 import { abi as DCA_HUB_ABI } from '@mean-finance/dca-v2-core/artifacts/contracts/DCAHub/DCAHub.sol/DCAHub.json';
 import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
@@ -24,7 +24,6 @@ contract('Swap for caller', () => {
   let governor: JsonRpcSigner;
   let cindy: SignerWithAddress, swapper: SignerWithAddress, recipient: SignerWithAddress;
   let DCAHubSwapper: DCAHubSwapper;
-  let DCAHubCompanion: DCAHubCompanion;
   let DCAHub: DCAHub;
   let initialPerformedSwaps: number;
   let snapshotId: string;
@@ -52,14 +51,13 @@ contract('Swap for caller', () => {
 
     await deterministicFactory.connect(governor).grantRole(await deterministicFactory.DEPLOYER_ROLE(), namedAccounts.deployer);
 
-    await deployments.run(['DCAHub', 'DCAHubCompanion', 'DCAHubSwapper'], {
+    await deployments.run(['DCAHub', 'DCAHubSwapper'], {
       resetMemory: true,
       deletePreviousDeployments: false,
       writeDeploymentsToFiles: false,
     });
 
     DCAHub = await ethers.getContract('DCAHub');
-    DCAHubCompanion = await ethers.getContract('DCAHubCompanion');
     DCAHubSwapper = await ethers.getContract('DCAHubSwapper');
 
     // Allow tokens

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -5,9 +5,10 @@ import { snapshot } from '@test-utils/evm';
 import { DCAFeeManager, DCAFeeManager__factory } from '@typechained';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { duration } from 'moment';
-import { behaviours } from '@test-utils';
-import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { behaviours, wallet } from '@test-utils';
 import { readArgFromEventOrFail } from '@test-utils/event-utils';
+import { TransactionResponse } from '@ethersproject/providers';
+import { IDCAFeeManager } from '@typechained/DCAFeeManager';
 
 contract('DCAFeeManager', () => {
   const HUB = '0x0000000000000000000000000000000000000001';
@@ -18,11 +19,11 @@ contract('DCAFeeManager', () => {
   const DEFAULT_DISTRIBUTION = [{ token: TOKEN_A, shares: MAX_SHARES }];
   let DCAFeeManager: DCAFeeManager;
   let DCAFeeManagerFactory: DCAFeeManager__factory;
-  let governor: SignerWithAddress;
+  let random: SignerWithAddress, governor: SignerWithAddress;
   let snapshotId: string;
 
   before('Setup accounts and contracts', async () => {
-    [, governor] = await ethers.getSigners();
+    [random, governor] = await ethers.getSigners();
     DCAFeeManagerFactory = await ethers.getContractFactory('contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager');
     DCAFeeManager = await DCAFeeManagerFactory.deploy(HUB, DEFAULT_DISTRIBUTION, governor.address);
     snapshotId = await snapshot.take();
@@ -47,6 +48,51 @@ contract('DCAFeeManager', () => {
         const distribution = await DCAFeeManager.targetTokensDistribution();
         expectDistributionsToBeEqual(distribution, DEFAULT_DISTRIBUTION);
       });
+    });
+  });
+
+  describe('setAccess', () => {
+    const USER = wallet.generateRandomAddress();
+    when('giving access to a user', () => {
+      let tx: TransactionResponse;
+      given(async () => {
+        tx = await DCAFeeManager.connect(governor).setAccess([{ user: USER, access: true }]);
+      });
+      then('user has access', async () => {
+        expect(await DCAFeeManager.hasAccess(USER)).to.be.true;
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(DCAFeeManager, 'NewAccess');
+        // Can't compare array of objects directly, so will read the arg and compare manually
+        const access: IDCAFeeManager.UserAccessStruct[] = await readArgFromEventOrFail(tx, 'NewAccess', 'access');
+        expect(access).to.have.lengthOf(1);
+        expect(access[0].user).to.equal(USER);
+        expect(access[0].access).to.equal(true);
+      });
+    });
+    when('taking access from a user', () => {
+      let tx: TransactionResponse;
+      given(async () => {
+        await DCAFeeManager.connect(governor).setAccess([{ user: USER, access: true }]);
+        tx = await DCAFeeManager.connect(governor).setAccess([{ user: USER, access: false }]);
+      });
+      then('user lost access', async () => {
+        expect(await DCAFeeManager.hasAccess(USER)).to.be.false;
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(DCAFeeManager, 'NewAccess');
+        // Can't compare array of objects directly, so will read the arg and compare manually
+        const access: IDCAFeeManager.UserAccessStruct[] = await readArgFromEventOrFail(tx, 'NewAccess', 'access');
+        expect(access).to.have.lengthOf(1);
+        expect(access[0].user).to.equal(USER);
+        expect(access[0].access).to.equal(false);
+      });
+    });
+    behaviours.shouldBeExecutableOnlyByGovernor({
+      contract: () => DCAFeeManager,
+      funcAndSignature: 'setAccess',
+      params: () => [[{ user: random.address, access: true }]],
+      governor: () => governor,
     });
   });
 
@@ -84,6 +130,10 @@ contract('DCAFeeManager', () => {
         { token: TOKEN_B, shares: MAX_SHARES / 2 },
       ],
       newDistribution: [{ token: TOKEN_C, shares: MAX_SHARES }],
+    });
+    shouldBeExecutableByGovernorOrAllowed({
+      funcAndSignature: 'setTargetTokensDistribution',
+      params: [{ token: TOKEN_B, shares: MAX_SHARES }],
     });
 
     function distributionTest({
@@ -125,5 +175,41 @@ contract('DCAFeeManager', () => {
       expect(actual[i].token).to.be.equal(expected[i].token);
       expect(actual[i].shares).to.be.equal(expected[i].shares);
     }
+  }
+
+  function shouldBeExecutableByGovernorOrAllowed({ funcAndSignature, params }: { funcAndSignature: string; params?: any[] | (() => any[]) }) {
+    let realParams: any[];
+    given(() => {
+      realParams = typeof params === 'function' ? params() : params ?? [];
+    });
+    when('called from allowed', () => {
+      let onlyAllowed: Promise<TransactionResponse>;
+      given(async () => {
+        await DCAFeeManager.setAccess([{ user: random.address, access: true }]);
+        onlyAllowed = (DCAFeeManager as any).connect(random)[funcAndSignature](...realParams!);
+      });
+      then(`tx is not reverted or not reverted with reason 'CallerMustBeOwnerOrHaveAccess'`, async () => {
+        await expect(onlyAllowed).to.not.be.revertedWith('CallerMustBeOwnerOrHaveAccess');
+      });
+    });
+    when('called by governor', () => {
+      let onlyGovernor: Promise<TransactionResponse>;
+      given(async () => {
+        onlyGovernor = (DCAFeeManager as any).connect(governor)[funcAndSignature](...realParams!);
+      });
+      then(`tx is not reverted or not reverted with reason 'CallerMustBeOwnerOrHaveAccess'`, async () => {
+        await expect(onlyGovernor).to.not.be.revertedWith('CallerMustBeOwnerOrHaveAccess');
+      });
+    });
+    when('not called from allowed or governor', () => {
+      let onlyGovernorAllowedTx: Promise<TransactionResponse>;
+      given(async () => {
+        const notAllowed = await wallet.generateRandom();
+        onlyGovernorAllowedTx = (DCAFeeManager as any).connect(notAllowed)[funcAndSignature](...realParams!);
+      });
+      then('tx is reverted with reason', async () => {
+        await expect(onlyGovernorAllowedTx).to.be.revertedWith('CallerMustBeOwnerOrHaveAccess');
+      });
+    });
   }
 });

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -1,53 +1,388 @@
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { contract, given, then, when } from '@test-utils/bdd';
 import { snapshot } from '@test-utils/evm';
-import { DCAFeeManager, DCAFeeManager__factory } from '@typechained';
+import {
+  DCAFeeManagerMock,
+  DCAFeeManagerMock__factory,
+  IDCAHub,
+  IDCAHubPositionHandler,
+  IERC20,
+  WrappedPlatformTokenMock,
+  WrappedPlatformTokenMock__factory,
+} from '@typechained';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { duration } from 'moment';
 import { behaviours, wallet } from '@test-utils';
 import { readArgFromEventOrFail } from '@test-utils/event-utils';
 import { TransactionResponse } from '@ethersproject/providers';
 import { IDCAFeeManager } from '@typechained/DCAFeeManager';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+import { BigNumber, BigNumberish, constants, utils } from 'ethers';
+
+chai.use(smock.matchers);
 
 contract('DCAFeeManager', () => {
-  const HUB = '0x0000000000000000000000000000000000000001';
   const TOKEN_A = '0x0000000000000000000000000000000000000010';
   const TOKEN_B = '0x0000000000000000000000000000000000000011';
-  const TOKEN_C = '0x0000000000000000000000000000000000000012';
   const MAX_SHARES = 10000;
-  const DEFAULT_DISTRIBUTION = [{ token: TOKEN_A, shares: MAX_SHARES }];
-  let DCAFeeManager: DCAFeeManager;
-  let DCAFeeManagerFactory: DCAFeeManager__factory;
+  const SWAP_INTERVAL = duration(1, 'day').asSeconds();
+  let wToken: WrappedPlatformTokenMock;
+  let DCAHub: FakeContract<IDCAHub>;
+  let DCAFeeManager: DCAFeeManagerMock;
+  let DCAFeeManagerFactory: DCAFeeManagerMock__factory;
+  let erc20Token: FakeContract<IERC20>;
   let random: SignerWithAddress, governor: SignerWithAddress;
   let snapshotId: string;
 
   before('Setup accounts and contracts', async () => {
     [random, governor] = await ethers.getSigners();
-    DCAFeeManagerFactory = await ethers.getContractFactory('contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager');
-    DCAFeeManager = await DCAFeeManagerFactory.deploy(HUB, DEFAULT_DISTRIBUTION, governor.address);
+    const wTokenFactory: WrappedPlatformTokenMock__factory = await ethers.getContractFactory(
+      'contracts/mocks/WrappedPlatformTokenMock.sol:WrappedPlatformTokenMock'
+    );
+    DCAHub = await smock.fake('IDCAHub');
+    erc20Token = await smock.fake('IERC20');
+    wToken = await wTokenFactory.deploy('WETH', 'WETH', 18);
+    await setProtocolBalance(wToken, utils.parseEther('100'));
+    DCAFeeManagerFactory = await ethers.getContractFactory('contracts/mocks/DCAFeeManager/DCAFeeManager.sol:DCAFeeManagerMock');
+    DCAFeeManager = await DCAFeeManagerFactory.deploy(DCAHub.address, wToken.address, governor.address);
     snapshotId = await snapshot.take();
   });
 
   beforeEach(async () => {
     await snapshot.revert(snapshotId);
+    DCAHub.platformBalance.reset();
+    DCAHub.withdrawFromPlatformBalance.reset();
+    DCAHub.withdrawSwappedMany.reset();
+    DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].reset();
+    DCAHub.increasePosition.reset();
+    DCAHub.terminate.reset();
+    erc20Token.allowance.reset();
+    erc20Token.approve.reset();
+    erc20Token.transfer.reset();
   });
 
   describe('constructor', () => {
     when('contract is initiated', () => {
       then('hub is set correctly', async () => {
-        expect(await DCAFeeManager.hub()).to.equal(HUB);
+        expect(await DCAFeeManager.hub()).to.equal(DCAHub.address);
       });
       then('max token total share is set correctly', async () => {
         expect(await DCAFeeManager.MAX_TOKEN_TOTAL_SHARE()).to.equal(MAX_SHARES);
       });
       then('swap interval is set to daily', async () => {
-        expect(await DCAFeeManager.SWAP_INTERVAL()).to.equal(duration(1, 'day').asSeconds());
+        expect(await DCAFeeManager.SWAP_INTERVAL()).to.equal(SWAP_INTERVAL);
       });
-      then('default distribution is set correctly', async () => {
-        const distribution = await DCAFeeManager.targetTokensDistribution();
-        expectDistributionsToBeEqual(distribution, DEFAULT_DISTRIBUTION);
+      then('wToken is set correctly', async () => {
+        expect(await DCAFeeManager.wToken()).to.equal(wToken.address);
       });
+    });
+  });
+
+  describe('withdrawProtocolToken', () => {
+    const RECIPIENT = wallet.generateRandomAddress();
+    when('we avoid withdrawing from platform balance', () => {
+      given(async () => {
+        await DCAFeeManager.connect(governor).withdrawProtocolToken(false, [], RECIPIENT);
+      });
+      then('no balance check is executed', () => {
+        expect(DCAHub.platformBalance).to.have.not.have.been.called;
+      });
+      then('no withdraw is made from the platform balance', () => {
+        expect(DCAHub.withdrawFromPlatformBalance).to.have.not.have.been.called;
+      });
+    });
+    when('platform balance is zero', () => {
+      given(async () => {
+        DCAHub.platformBalance.returns(0);
+        await DCAFeeManager.connect(governor).withdrawProtocolToken(true, [], RECIPIENT);
+      });
+      then('no withdraw is made from the platform balance', () => {
+        expect(DCAHub.withdrawFromPlatformBalance).to.have.not.have.been.called;
+      });
+    });
+    when('the position ids list is empty', () => {
+      given(async () => {
+        await DCAFeeManager.connect(governor).withdrawProtocolToken(true, [], RECIPIENT);
+      });
+      then('no withdraw is executed', () => {
+        expect(DCAHub.withdrawSwappedMany).to.have.not.have.been.called;
+      });
+    });
+    when('all sources have balance', () => {
+      const PLATFORM_BALANCE = utils.parseEther('1');
+      const POSITION_IDS = [1, 2, 3];
+      const TOTAL_BALANCE = utils.parseEther('1');
+      given(async () => {
+        DCAHub.platformBalance.returns(PLATFORM_BALANCE);
+        await wToken.mint(DCAFeeManager.address, TOTAL_BALANCE);
+        await DCAFeeManager.connect(governor).withdrawProtocolToken(true, POSITION_IDS, RECIPIENT);
+      });
+      then('platform balance is withdrawn', () => {
+        expect(DCAHub.withdrawFromPlatformBalance).to.have.have.been.calledOnce;
+        const [amountToWithdraw, recipient] = DCAHub.withdrawFromPlatformBalance.getCall(0).args as [AmountToWithdraw[], string];
+        expectAmounToWithdrawToBe(amountToWithdraw, [{ token: wToken.address, amount: PLATFORM_BALANCE }]);
+        expect(recipient).to.equal(DCAFeeManager.address);
+      });
+      then('swapped balance is withdrawn from positions', () => {
+        expect(DCAHub.withdrawSwappedMany).to.have.have.been.calledOnce;
+        const [positionSets, recipient] = DCAHub.withdrawSwappedMany.getCall(0).args as [PositionSet[], string];
+        expectPositionSetsToBe(positionSets, [{ token: wToken.address, positionIds: POSITION_IDS }]);
+        expect(recipient).to.equal(DCAFeeManager.address);
+      });
+      then('total balance is unwrapped and sent to the recipient', async () => {
+        expect(await wToken.balanceOf(DCAFeeManager.address)).to.equal(0);
+        expect(await getProtocolBalance(RECIPIENT)).to.equal(TOTAL_BALANCE);
+      });
+    });
+    shouldOnlyBeExecutableByGovernorOrAllowed({
+      funcAndSignature: 'withdrawProtocolToken',
+      params: [true, [], RECIPIENT],
+    });
+  });
+
+  describe('withdrawFromPlatformBalance', () => {
+    const RECIPIENT = wallet.generateRandomAddress();
+    when('withdraw is executed', () => {
+      const AMOUNT_TO_WITHDRAW = [{ token: TOKEN_A, amount: utils.parseEther('1') }];
+      given(async () => {
+        await DCAFeeManager.connect(governor).withdrawFromPlatformBalance(AMOUNT_TO_WITHDRAW, RECIPIENT);
+      });
+      then('hub is called correctly', () => {
+        expect(DCAHub.withdrawFromPlatformBalance).to.have.been.calledOnce;
+        const [amountToWithdraw, recipient] = DCAHub.withdrawFromPlatformBalance.getCall(0).args as [AmountToWithdraw[], string];
+        expectAmounToWithdrawToBe(amountToWithdraw, AMOUNT_TO_WITHDRAW);
+        expect(recipient).to.equal(RECIPIENT);
+      });
+    });
+    shouldOnlyBeExecutableByGovernorOrAllowed({
+      funcAndSignature: 'withdrawFromPlatformBalance',
+      params: [[], RECIPIENT],
+    });
+  });
+
+  describe('withdrawFromBalance', () => {
+    const RECIPIENT = wallet.generateRandomAddress();
+    when('withdraw is executed', () => {
+      const AMOUNT_TO_WITHDRAW = utils.parseEther('1');
+      given(async () => {
+        erc20Token.transfer.returns(true);
+        await DCAFeeManager.connect(governor).withdrawFromBalance([{ token: erc20Token.address, amount: AMOUNT_TO_WITHDRAW }], RECIPIENT);
+      });
+      then('token is called correctly', () => {
+        expect(erc20Token.transfer).to.have.been.calledOnceWith(RECIPIENT, AMOUNT_TO_WITHDRAW);
+      });
+    });
+    shouldOnlyBeExecutableByGovernorOrAllowed({
+      funcAndSignature: 'withdrawFromBalance',
+      params: [[], RECIPIENT],
+    });
+  });
+
+  describe('withdrawFromPositions', () => {
+    const RECIPIENT = wallet.generateRandomAddress();
+    when('withdraw is executed', () => {
+      const POSITION_SETS = [{ token: TOKEN_A, positionIds: [1, 2, 3] }];
+      given(async () => {
+        await DCAFeeManager.connect(governor).withdrawFromPositions(POSITION_SETS, RECIPIENT);
+      });
+      then('hub is called correctly', () => {
+        expect(DCAHub.withdrawSwappedMany).to.have.been.calledOnce;
+        const [positionSets, recipient] = DCAHub.withdrawSwappedMany.getCall(0).args as [PositionSet[], string];
+        expectPositionSetsToBe(positionSets, POSITION_SETS);
+        expect(recipient).to.equal(RECIPIENT);
+      });
+    });
+    shouldOnlyBeExecutableByGovernorOrAllowed({
+      funcAndSignature: 'withdrawFromPositions',
+      params: [[], RECIPIENT],
+    });
+  });
+
+  describe('fillPositions', () => {
+    const AMOUNT_OF_SWAPS = 10;
+    const FULL_AMOUNT = utils.parseEther('1');
+    const DISTRIBUTION = [
+      { token: TOKEN_A, shares: MAX_SHARES / 2 },
+      { token: TOKEN_B, shares: MAX_SHARES / 2 },
+    ];
+    const POSITION_ID_TOKEN_A = 1;
+    const POSITION_ID_TOKEN_B = 2;
+    when('allowance is zero', () => {
+      given(async () => {
+        erc20Token.allowance.returns(0);
+        await DCAFeeManager.connect(governor).fillPositions(
+          [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
+          DISTRIBUTION
+        );
+      });
+      then('full allowance is set', () => {
+        expect(erc20Token.approve).to.have.been.calledOnceWith(DCAHub.address, constants.MaxUint256);
+      });
+    });
+    when('there is no position created', () => {
+      describe('and deposit fails', () => {
+        given(async () => {
+          DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].revertsAtCall(0);
+          DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].returnsAtCall(1, POSITION_ID_TOKEN_B);
+          await DCAFeeManager.connect(governor).fillPositions(
+            [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
+            DISTRIBUTION
+          );
+        });
+        then('full amount is spent on last target token', () => {
+          expect(DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])']).to.have.been.calledTwice;
+          expect(DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])']).to.have.been.calledWith(
+            erc20Token.address,
+            TOKEN_B,
+            FULL_AMOUNT,
+            AMOUNT_OF_SWAPS,
+            SWAP_INTERVAL,
+            DCAFeeManager.address,
+            []
+          );
+        });
+        then('position is stored for the pair', async () => {
+          const key = await DCAFeeManager.getPositionKey(erc20Token.address, TOKEN_B);
+          expect(await DCAFeeManager.positions(key)).to.equal(POSITION_ID_TOKEN_B);
+        });
+        then('position is stored for the to token', async () => {
+          const positions = await DCAFeeManager.positionsWithToken(TOKEN_B);
+          expect(positions).to.eql([BigNumber.from(POSITION_ID_TOKEN_B)]);
+        });
+      });
+      describe('and deposit works', () => {
+        given(async () => {
+          DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].returnsAtCall(0, POSITION_ID_TOKEN_A);
+          DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].returnsAtCall(1, POSITION_ID_TOKEN_B);
+          await DCAFeeManager.connect(governor).fillPositions(
+            [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
+            DISTRIBUTION
+          );
+        });
+        then('deposit with token A is made correctly', () => {
+          expect(DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])']).to.have.been.calledWith(
+            erc20Token.address,
+            TOKEN_A,
+            FULL_AMOUNT.div(2),
+            AMOUNT_OF_SWAPS,
+            SWAP_INTERVAL,
+            DCAFeeManager.address,
+            []
+          );
+        });
+        then('deposit with token B is made correctly', () => {
+          expect(DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])']).to.have.been.calledWith(
+            erc20Token.address,
+            TOKEN_B,
+            FULL_AMOUNT.div(2),
+            AMOUNT_OF_SWAPS,
+            SWAP_INTERVAL,
+            DCAFeeManager.address,
+            []
+          );
+        });
+        then('there were only two deposits made', () => {
+          expect(DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])']).to.have.been.calledTwice;
+        });
+        then('position is stored for the pair with token A', async () => {
+          const key = await DCAFeeManager.getPositionKey(erc20Token.address, TOKEN_A);
+          expect(await DCAFeeManager.positions(key)).to.equal(POSITION_ID_TOKEN_A);
+        });
+        then('position is stored for the pair with token B', async () => {
+          const key = await DCAFeeManager.getPositionKey(erc20Token.address, TOKEN_B);
+          expect(await DCAFeeManager.positions(key)).to.equal(POSITION_ID_TOKEN_B);
+        });
+        then('position is stored for token A', async () => {
+          const positions = await DCAFeeManager.positionsWithToken(TOKEN_A);
+          expect(positions).to.eql([BigNumber.from(POSITION_ID_TOKEN_A)]);
+        });
+        then('position is stored for token B', async () => {
+          const positions = await DCAFeeManager.positionsWithToken(TOKEN_A);
+          expect(positions).to.eql([BigNumber.from(POSITION_ID_TOKEN_A)]);
+        });
+      });
+    });
+
+    when('there is a position created', () => {
+      given(async () => {
+        await DCAFeeManager.setPosition(erc20Token.address, TOKEN_A, POSITION_ID_TOKEN_A);
+        await DCAFeeManager.setPosition(erc20Token.address, TOKEN_B, POSITION_ID_TOKEN_B);
+      });
+      describe('and increase fails', () => {
+        given(async () => {
+          DCAHub.increasePosition.revertsAtCall(0);
+          await DCAFeeManager.connect(governor).fillPositions(
+            [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
+            DISTRIBUTION
+          );
+        });
+        then('full amount is spent on last target token', () => {
+          expect(DCAHub.increasePosition).to.have.been.calledTwice;
+          expect(DCAHub.increasePosition).to.have.been.calledWith(POSITION_ID_TOKEN_B, FULL_AMOUNT, AMOUNT_OF_SWAPS);
+        });
+      });
+      describe('and increase works', () => {
+        given(async () => {
+          await DCAFeeManager.connect(governor).fillPositions(
+            [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
+            DISTRIBUTION
+          );
+        });
+        then('increase with token A is made correctly', () => {
+          expect(DCAHub.increasePosition).to.have.been.calledWith(POSITION_ID_TOKEN_A, FULL_AMOUNT.div(2), AMOUNT_OF_SWAPS);
+        });
+        then('increase with token B is made correctly', () => {
+          expect(DCAHub.increasePosition).to.have.been.calledWith(POSITION_ID_TOKEN_B, FULL_AMOUNT.div(2), AMOUNT_OF_SWAPS);
+        });
+        then('there were only two increases made', () => {
+          expect(DCAHub.increasePosition).to.have.been.calledTwice;
+        });
+      });
+    });
+
+    shouldOnlyBeExecutableByGovernorOrAllowed({
+      funcAndSignature: 'fillPositions',
+      params: () => [[{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }], DISTRIBUTION],
+    });
+  });
+
+  describe('terminatePositions', () => {
+    const RECIPIENT = wallet.generateRandomAddress();
+    const POSITION_IDS = [1, 2];
+    when('function is executed', () => {
+      given(async () => {
+        DCAHub.userPosition.returns(({ _positionId }: { _positionId: BigNumber }) => ({
+          from: erc20Token.address,
+          to: _positionId.eq(1) ? TOKEN_A : TOKEN_B,
+          swapInterval: constants.Zero,
+          swapsExecuted: constants.Zero,
+          swapped: constants.Zero,
+          swapsLeft: constants.Zero,
+          remaining: constants.Zero,
+          rate: constants.Zero,
+        }));
+        await DCAFeeManager.setPosition(erc20Token.address, TOKEN_A, 1);
+        await DCAFeeManager.setPosition(erc20Token.address, TOKEN_B, 2);
+        await DCAFeeManager.connect(governor).terminatePositions(POSITION_IDS, RECIPIENT);
+      });
+      then('position 1 is terminated and deleted from fee manager', async () => {
+        expect(DCAHub.terminate).to.have.been.calledWith(1, RECIPIENT, RECIPIENT);
+        const positionKey = await DCAFeeManager.getPositionKey(erc20Token.address, TOKEN_A);
+        expect(await DCAFeeManager.positions(positionKey)).to.equal(0);
+      });
+      then('position 2 is terminated and deleted from fee manager', async () => {
+        expect(DCAHub.terminate).to.have.been.calledWith(2, RECIPIENT, RECIPIENT);
+        const positionKey = await DCAFeeManager.getPositionKey(erc20Token.address, TOKEN_B);
+        expect(await DCAFeeManager.positions(positionKey)).to.equal(0);
+      });
+      then('only two positions were terminated', () => {
+        expect(DCAHub.terminate).to.have.been.calledTwice;
+      });
+    });
+    shouldOnlyBeExecutableByGovernorOrAllowed({
+      funcAndSignature: 'terminatePositions',
+      params: [[], RECIPIENT],
     });
   });
 
@@ -96,88 +431,77 @@ contract('DCAFeeManager', () => {
     });
   });
 
-  describe('setTargetTokensDistribution', () => {
-    when('not all shares are assigned', () => {
-      then('reverts with message', async () => {
-        await behaviours.txShouldRevertWithMessage({
-          contract: DCAFeeManager.connect(governor),
-          func: 'setTargetTokensDistribution',
-          args: [
-            [
-              { token: TOKEN_A, shares: 10 },
-              { token: TOKEN_B, shares: 50 },
-            ],
-          ],
-          message: 'InvalidAmountOfShares',
-        });
+  describe('resetAllowance', () => {
+    when('function is executed', () => {
+      given(async () => {
+        await DCAFeeManager.resetAllowance(erc20Token.address);
+      });
+      then('allowance is reset', async () => {
+        expect(erc20Token.approve).to.have.been.calledTwice;
+        expect(erc20Token.approve).to.have.been.calledWith(DCAHub.address, 0);
+        expect(erc20Token.approve).to.have.been.calledWith(DCAHub.address, constants.MaxUint256);
       });
     });
-    distributionTest({
-      when: 'the number of target tokens increases',
-      newDistribution: [
-        { token: TOKEN_B, shares: MAX_SHARES / 2 },
-        { token: TOKEN_C, shares: MAX_SHARES / 2 },
-      ],
-    });
-    distributionTest({
-      when: 'the number of target tokens stays the same',
-      newDistribution: [{ token: TOKEN_B, shares: MAX_SHARES }],
-    });
-    distributionTest({
-      when: 'the number of target tokens is reduced',
-      prevDistribution: [
-        { token: TOKEN_A, shares: MAX_SHARES / 2 },
-        { token: TOKEN_B, shares: MAX_SHARES / 2 },
-      ],
-      newDistribution: [{ token: TOKEN_C, shares: MAX_SHARES }],
-    });
-    shouldBeExecutableByGovernorOrAllowed({
-      funcAndSignature: 'setTargetTokensDistribution',
-      params: [[{ token: TOKEN_B, shares: MAX_SHARES }]],
-    });
+  });
 
-    function distributionTest({
-      when: title,
-      prevDistribution,
-      newDistribution,
-    }: {
-      when: string;
-      prevDistribution?: Distribution;
-      newDistribution: Distribution;
-    }) {
-      when(title, () => {
-        let tx: TransactionResponse;
-        given(async () => {
-          if (prevDistribution) {
-            await DCAFeeManager.connect(governor).setTargetTokensDistribution(prevDistribution);
-          }
-          tx = await DCAFeeManager.connect(governor).setTargetTokensDistribution(newDistribution);
-        });
-        then('distribution is set correctly', async () => {
-          const distribution = await DCAFeeManager.targetTokensDistribution();
-          expectDistributionsToBeEqual(distribution, newDistribution);
-        });
-        then('event is emitted', async () => {
-          await expect(tx).to.emit(DCAFeeManager, 'NewDistribution');
-
-          // Can't compare array of objects directly, so will read the arg and compare manually
-          const distribution: Distribution = await readArgFromEventOrFail(tx, 'NewDistribution', 'distribution');
-          expectDistributionsToBeEqual(distribution, newDistribution);
-        });
+  describe('availableBalances', () => {
+    when('function is executed', () => {
+      const PLATFORM_BALANCE = utils.parseEther('1');
+      const FEE_MANAGER_BALANCE = utils.parseEther('2');
+      let position1: IDCAHubPositionHandler.UserPositionStruct, position2: IDCAHubPositionHandler.UserPositionStruct;
+      given(async () => {
+        DCAHub.platformBalance.returns(PLATFORM_BALANCE);
+        erc20Token.balanceOf.returns(FEE_MANAGER_BALANCE);
+        position1 = positionWith(TOKEN_A, erc20Token.address, utils.parseEther('1'));
+        position2 = positionWith(TOKEN_B, erc20Token.address, utils.parseEther('3'));
+        DCAHub.userPosition.returns(({ _positionId }: { _positionId: BigNumber }) => (_positionId.eq(1) ? position1 : position2));
+        await DCAFeeManager.setPositionsWithToken(erc20Token.address, [1, 2]);
       });
+      then('balances are returned correctly', async () => {
+        const balances = await DCAFeeManager.availableBalances([erc20Token.address]);
+        expect(balances).to.have.lengthOf(1);
+        expect(balances[0].token).to.equal(erc20Token.address);
+        expect(balances[0].platformBalance).to.equal(PLATFORM_BALANCE);
+        expect(balances[0].feeManagerBalance).to.equal(FEE_MANAGER_BALANCE);
+        expect(balances[0].positions).to.have.lengthOf(2);
+        expectUserPositionToBeEqual(balances[0].positions[0], position1, 1);
+        expectUserPositionToBeEqual(balances[0].positions[1], position2, 2);
+      });
+    });
+
+    function expectUserPositionToBeEqual(
+      actual: IDCAFeeManager.PositionBalanceStructOutput,
+      expected: IDCAHubPositionHandler.UserPositionStruct,
+      positionId: BigNumberish
+    ) {
+      expect(actual.positionId).to.equal(positionId);
+      expect(actual.from).to.equal(expected.from);
+      expect(actual.to).to.equal(expected.to);
+      expect(actual.swapped).to.equal(expected.swapped);
+      expect(actual.remaining).to.equal(expected.remaining);
+    }
+
+    function positionWith(from: string, to: string, swapped: BigNumberish) {
+      return {
+        from,
+        to,
+        swapInterval: constants.Zero,
+        swapsExecuted: constants.Zero,
+        swapped,
+        swapsLeft: constants.Zero,
+        remaining: constants.Zero,
+        rate: constants.Zero,
+      };
     }
   });
 
-  type Distribution = { token: string; shares: number }[];
-  function expectDistributionsToBeEqual(actual: Distribution, expected: Distribution) {
-    expect(actual).to.be.lengthOf(expected.length);
-    for (let i = 0; i < actual.length; i++) {
-      expect(actual[i].token).to.be.equal(expected[i].token);
-      expect(actual[i].shares).to.be.equal(expected[i].shares);
-    }
-  }
-
-  function shouldBeExecutableByGovernorOrAllowed({ funcAndSignature, params }: { funcAndSignature: string; params?: any[] | (() => any[]) }) {
+  function shouldOnlyBeExecutableByGovernorOrAllowed({
+    funcAndSignature,
+    params,
+  }: {
+    funcAndSignature: string;
+    params?: any[] | (() => any[]);
+  }) {
     let realParams: any[];
     given(() => {
       realParams = typeof params === 'function' ? params() : params ?? [];
@@ -211,5 +535,32 @@ contract('DCAFeeManager', () => {
         await expect(onlyGovernorAllowedTx).to.be.revertedWith('CallerMustBeOwnerOrHaveAccess');
       });
     });
+  }
+
+  function getProtocolBalance(address: string) {
+    return ethers.provider.getBalance(address);
+  }
+
+  async function setProtocolBalance(recipient: { address: string }, amount: BigNumber) {
+    await ethers.provider.send('hardhat_setBalance', [recipient.address, ethers.utils.hexValue(amount)]);
+    return BigNumber.from(amount);
+  }
+
+  type AmountToWithdraw = { token: string; amount: BigNumberish };
+  function expectAmounToWithdrawToBe(actual: AmountToWithdraw[], expected: AmountToWithdraw[]) {
+    expect(actual).to.have.lengthOf(expected.length);
+    for (let i = 0; i < actual.length; i++) {
+      expect(actual[i].token).to.equal(expected[i].token);
+      expect(actual[i].amount).to.equal(expected[i].amount);
+    }
+  }
+
+  type PositionSet = { token: string; positionIds: BigNumberish[] };
+  function expectPositionSetsToBe(actual: PositionSet[], expected: PositionSet[]) {
+    expect(actual).to.have.lengthOf(expected.length);
+    for (let i = 0; i < actual.length; i++) {
+      expect(actual[i].token).to.equal(expected[i].token);
+      expect(actual[i].positionIds).to.eql(expected[i].positionIds.map(BigNumber.from));
+    }
   }
 });

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -100,7 +100,7 @@ contract('DCAFeeManager', () => {
     when('not all shares are assigned', () => {
       then('reverts with message', async () => {
         await behaviours.txShouldRevertWithMessage({
-          contract: DCAFeeManager,
+          contract: DCAFeeManager.connect(governor),
           func: 'setTargetTokensDistribution',
           args: [
             [
@@ -133,7 +133,7 @@ contract('DCAFeeManager', () => {
     });
     shouldBeExecutableByGovernorOrAllowed({
       funcAndSignature: 'setTargetTokensDistribution',
-      params: [{ token: TOKEN_B, shares: MAX_SHARES }],
+      params: [[{ token: TOKEN_B, shares: MAX_SHARES }]],
     });
 
     function distributionTest({
@@ -149,9 +149,9 @@ contract('DCAFeeManager', () => {
         let tx: TransactionResponse;
         given(async () => {
           if (prevDistribution) {
-            await DCAFeeManager.setTargetTokensDistribution(prevDistribution);
+            await DCAFeeManager.connect(governor).setTargetTokensDistribution(prevDistribution);
           }
-          tx = await DCAFeeManager.setTargetTokensDistribution(newDistribution);
+          tx = await DCAFeeManager.connect(governor).setTargetTokensDistribution(newDistribution);
         });
         then('distribution is set correctly', async () => {
           const distribution = await DCAFeeManager.targetTokensDistribution();
@@ -185,7 +185,7 @@ contract('DCAFeeManager', () => {
     when('called from allowed', () => {
       let onlyAllowed: Promise<TransactionResponse>;
       given(async () => {
-        await DCAFeeManager.setAccess([{ user: random.address, access: true }]);
+        await DCAFeeManager.connect(governor).setAccess([{ user: random.address, access: true }]);
         onlyAllowed = (DCAFeeManager as any).connect(random)[funcAndSignature](...realParams!);
       });
       then(`tx is not reverted or not reverted with reason 'CallerMustBeOwnerOrHaveAccess'`, async () => {

--- a/test/utils/swap-utils.ts
+++ b/test/utils/swap-utils.ts
@@ -1,0 +1,86 @@
+import { BigNumber } from 'ethers';
+
+export type TokenAddress = string;
+
+export type Pair = {
+  tokenA: TokenAddress;
+  tokenB: TokenAddress;
+};
+
+export type Borrow = {
+  token: TokenAddress;
+  amount: BigNumber;
+};
+
+export type PairIndex = {
+  indexTokenA: number;
+  indexTokenB: number;
+};
+
+export function buildGetNextSwapInfoInput(
+  pairsToSwap: Pair[],
+  checkAvailableToBorrow: TokenAddress[]
+): { tokens: TokenAddress[]; pairIndexes: PairIndex[] } {
+  const fakeAmounts = checkAvailableToBorrow.map((token) => ({ token, amount: BigNumber.from(0) }));
+  const { tokens, pairIndexes } = buildSwapInput(pairsToSwap, fakeAmounts);
+  return { tokens, pairIndexes };
+}
+
+export function buildSwapInput(
+  pairsToSwap: Pair[],
+  borrow: Borrow[]
+): { tokens: TokenAddress[]; pairIndexes: PairIndex[]; borrow: BigNumber[] } {
+  const tokens: TokenAddress[] = getUniqueTokens(pairsToSwap, borrow);
+  const pairIndexes = getIndexes(pairsToSwap, tokens);
+  assertValid(pairIndexes);
+  const toBorrow = buildBorrowArray(tokens, borrow);
+  return { tokens, pairIndexes, borrow: toBorrow };
+}
+
+function buildBorrowArray(tokens: TokenAddress[], borrow: Borrow[]): BigNumber[] {
+  const borrowMap = new Map(borrow.map(({ token, amount }) => [token, amount]));
+  return tokens.map((token) => borrowMap.get(token) ?? BigNumber.from(0));
+}
+
+function assertValid(indexes: PairIndex[]) {
+  for (const { indexTokenA, indexTokenB } of indexes) {
+    if (indexTokenA === indexTokenB) {
+      throw Error('Found duplicates in same pair');
+    }
+  }
+
+  for (let i = 1; i < indexes.length; i++) {
+    if (indexes[i - 1].indexTokenA === indexes[i].indexTokenA && indexes[i - 1].indexTokenB === indexes[i].indexTokenB) {
+      throw Error('Found duplicates');
+    }
+  }
+}
+
+/**
+ * Given a list of pairs and a list of sorted tokens, maps each pair into the index of each token
+ * (inside the list of tokens). The list of indexes will also be sorted, first by tokenA and then by tokenB
+ */
+function getIndexes(pairs: Pair[], tokens: TokenAddress[]): PairIndex[] {
+  return pairs
+    .map(({ tokenA, tokenB }) => ({ indexTokenA: tokens.indexOf(tokenA), indexTokenB: tokens.indexOf(tokenB) }))
+    .map(({ indexTokenA, indexTokenB }) => ({
+      indexTokenA: Math.min(indexTokenA, indexTokenB),
+      indexTokenB: Math.max(indexTokenA, indexTokenB),
+    }))
+    .sort((a, b) => a.indexTokenA - b.indexTokenA || a.indexTokenB - b.indexTokenB);
+}
+
+/** Given a list of pairs, returns a sorted list of the tokens involved */
+function getUniqueTokens(pairs: Pair[], borrow: Borrow[]): TokenAddress[] {
+  const tokenSet: Set<TokenAddress> = new Set();
+  for (const { tokenA, tokenB } of pairs) {
+    tokenSet.add(tokenA);
+    tokenSet.add(tokenB);
+  }
+
+  for (const { token } of borrow) {
+    tokenSet.add(token);
+  }
+
+  return [...tokenSet].sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
We are now adding access management. The contract owner/governor will be able to give other users the ability to set the target tokens distribution, and also make withdraws (in future PRs)