### PR TITLE
refactor: remove token distribution

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -16,22 +16,13 @@ contract DCAFeeManager is Governable, IDCAFeeManager {
   /// @inheritdoc IDCAFeeManager
   mapping(address => bool) public hasAccess;
 
-  TargetTokenShare[] internal _distribution;
-
   constructor(
     IDCAHub _hub,
     IWrappedProtocolToken _wToken,
-    TargetTokenShare[] memory _distributionToSet,
     address _governor
   ) Governable(_governor) {
     hub = _hub;
     wToken = _wToken;
-    _setTargetTokensDistribution(_distributionToSet);
-  }
-
-  /// @inheritdoc IDCAFeeManager
-  function targetTokensDistribution() external view returns (TargetTokenShare[] memory) {
-    return _distribution;
   }
 
   /// @inheritdoc IDCAFeeManager
@@ -67,40 +58,7 @@ contract DCAFeeManager is Governable, IDCAFeeManager {
     emit NewAccess(_access);
   }
 
-  /// @inheritdoc IDCAFeeManager
-  function setTargetTokensDistribution(TargetTokenShare[] calldata _newDistribution) external onlyOwnerOrAllowed {
-    _setTargetTokensDistribution(_newDistribution);
-  }
-
   receive() external payable {}
-
-  function _setTargetTokensDistribution(TargetTokenShare[] memory _newDistribution) internal {
-    uint256 _currentTargetTokens = _distribution.length;
-    uint256 _min = _currentTargetTokens < _newDistribution.length ? _currentTargetTokens : _newDistribution.length;
-
-    uint16 _assignedShares;
-    for (uint256 i; i < _min; i++) {
-      // Rewrite storage
-      _assignedShares += _newDistribution[i].shares;
-      _distribution[i] = _newDistribution[i];
-    }
-
-    if (_currentTargetTokens < _newDistribution.length) {
-      // If have more tokens than before, then push
-      for (uint256 i = _min; i < _newDistribution.length; i++) {
-        _assignedShares += _newDistribution[i].shares;
-        _distribution.push(_newDistribution[i]);
-      }
-    } else if (_currentTargetTokens > _newDistribution.length) {
-      // If have less tokens than before, then remove extra tokens
-      for (uint256 i = _min; i < _currentTargetTokens; i++) {
-        _distribution.pop();
-      }
-    }
-
-    if (_assignedShares != MAX_TOKEN_TOTAL_SHARE) revert InvalidAmountOfShares();
-    emit NewDistribution(_newDistribution);
-  }
 
   modifier onlyOwnerOrAllowed() {
     if (!isGovernor(msg.sender) && !hasAccess[msg.sender]) revert CallerMustBeOwnerOrHaveAccess();

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -28,15 +28,6 @@ interface IDCAFeeManager is IGovernable {
   /// @notice Thrown when a user tries to execute a permissioned action without the access to do so
   error CallerMustBeOwnerOrHaveAccess();
 
-  /// @notice Thrown when a user tries to set an invalid distribution
-  error InvalidAmountOfShares();
-
-  /**
-   * @notice Emitted when a new distribution is set
-   * @param distribution The new distribution
-   */
-  event NewDistribution(TargetTokenShare[] distribution);
-
   /**
    * @notice Emitted when access is modified for some users
    * @param access The modified users and their new access
@@ -75,15 +66,7 @@ interface IDCAFeeManager is IGovernable {
   function wToken() external view returns (IWrappedProtocolToken);
 
   /**
-   * @notice Returns the distribution for the target tokens. Target tokens are the tokens that we
-   *         want to swap the fees to. We can assign a distribution to convert to many different tokens
-   * @return The distribution for the target tokens
-   */
-  function targetTokensDistribution() external view returns (TargetTokenShare[] memory);
-
-  /**
-   * @notice Returns whether the given user has access to set the target tokens distribution or
-   *         execute withdraws
+   * @notice Returns whether the given user has access to fill positions or execute withdraws
    * @param user The user to check access for
    * @return Whether the given user has access
    */
@@ -105,11 +88,4 @@ interface IDCAFeeManager is IGovernable {
    * @param access The users to affect, and how to affect them
    */
   function setAccess(UserAccess[] calldata access) external;
-
-  /**
-   * @notice Sets the distribution for the target tokens
-   * @dev Can only be set by the owner or allowed users
-   * @param distribution The new distribution to set
-   */
-  function setTargetTokensDistribution(TargetTokenShare[] calldata distribution) external;
 }


### PR DESCRIPTION
We are basically undoing #77. I realized that it would be better if the action to take fees and send fill positions was permissioned, so we can just take the distribution as a parameter, instead of having it stored

My bad 😅 