### PR TITLE
feat: add reset allowance

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -116,6 +116,12 @@ contract DCAFeeManager is Governable, IDCAFeeManager {
     emit NewAccess(_access);
   }
 
+  /// @inheritdoc IDCAFeeManager
+  function resetAllowance(IERC20 _token) external {
+    _token.approve(address(hub), 0); // We do this first because some tokens (like USDT) will fail if we  don't
+    _token.approve(address(hub), type(uint256).max);
+  }
+
   function getPositionKey(address _from, address _to) public pure returns (bytes32) {
     return keccak256(abi.encodePacked(_from, _to));
   }

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -146,4 +146,10 @@ interface IDCAFeeManager is IGovernable {
    * @param access The users to affect, and how to affect them
    */
   function setAccess(UserAccess[] calldata access) external;
+
+  /**
+   * @notice Sets the maximum allowance to the DCA Hub, for the given token
+   * @param token The token to set the allowance for
+   */
+  function resetAllowance(IERC20 token) external;
 }

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -407,6 +407,19 @@ contract('DCAFeeManager', () => {
     });
   });
 
+  describe('resetAllowance', () => {
+    when('function is executed', () => {
+      given(async () => {
+        await DCAFeeManager.resetAllowance(erc20Token.address);
+      });
+      then('allowance is reset', async () => {
+        expect(erc20Token.approve).to.have.been.calledTwice;
+        expect(erc20Token.approve).to.have.been.calledWith(DCAHub.address, 0);
+        expect(erc20Token.approve).to.have.been.calledWith(DCAHub.address, constants.MaxUint256);
+      });
+    });
+  });
+
   function shouldOnlyBeExecutableByGovernorOrAllowed({
     funcAndSignature,
     params,


### PR DESCRIPTION
We are now adding a way to reset the allowance for a specific token. Anyone will be able to pay the gas cost of doing so