### PR TITLE
feat: enable specifying if withdraw from platfrom

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -33,13 +33,19 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   }
 
   /// @inheritdoc IDCAFeeManager
-  function withdrawProtocolToken(uint256[] calldata _positionIds, address payable _recipient) external onlyOwnerOrAllowed {
+  function withdrawProtocolToken(
+    bool _withdrawFromPlatform,
+    uint256[] calldata _positionIds,
+    address payable _recipient
+  ) external onlyOwnerOrAllowed {
     // Withdraw wToken from platform balance
-    uint256 _platformBalance = hub.platformBalance(address(wToken));
-    if (_platformBalance > 0) {
-      IDCAHub.AmountOfToken[] memory _amountToWithdraw = new IDCAHub.AmountOfToken[](1);
-      _amountToWithdraw[0] = IDCAHub.AmountOfToken({token: address(wToken), amount: _platformBalance});
-      hub.withdrawFromPlatformBalance(_amountToWithdraw, address(this));
+    if (_withdrawFromPlatform) {
+      uint256 _platformBalance = hub.platformBalance(address(wToken));
+      if (_platformBalance > 0) {
+        IDCAHub.AmountOfToken[] memory _amountToWithdraw = new IDCAHub.AmountOfToken[](1);
+        _amountToWithdraw[0] = IDCAHub.AmountOfToken({token: address(wToken), amount: _platformBalance});
+        hub.withdrawFromPlatformBalance(_amountToWithdraw, address(this));
+      }
     }
 
     // Withdraw wToken from positions

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -106,11 +106,16 @@ interface IDCAFeeManager is IGovernable {
    * @notice Withdraws all wToken balance from the platform balance and the given positions,
    *         unwraps it in exchange for the protocol token, and sends it to the given recipient
    * @dev Can only be executed by the owner or allowed users
+   * @param withdrawFromPlatform Specify if we want to withdraw from the platform balance or not
    * @param positionIds The ids of the positions that we want to withdraw wToken from. These positions
    *                    have swapped other tokens in exchange for wToken
    * @param recipient The address of the recipient, that will receive all the protocol token balance
    */
-  function withdrawProtocolToken(uint256[] calldata positionIds, address payable recipient) external;
+  function withdrawProtocolToken(
+    bool withdrawFromPlatform,
+    uint256[] calldata positionIds,
+    address payable recipient
+  ) external;
 
   /**
    * @notice Withdraws tokens from the platform balance, and sends them to the given recipient

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -135,7 +135,7 @@ contract('DCAFeeManager', () => {
     expect(wethPlatformBalance.gt(0)).to.be.true;
 
     // Execute withdraw as protocol token
-    await DCAFeeManager.connect(allowed).withdrawProtocolToken([2, 3], RECIPIENT);
+    await DCAFeeManager.connect(allowed).withdrawProtocolToken(true, [2, 3], RECIPIENT);
 
     // Make sure that everything was transferred to recipient
     const recipientBalance = await ethers.provider.getBalance(RECIPIENT);


### PR DESCRIPTION
Before this change, when we called `withdrawProtocolToken`, we would always withdraw WETH (or the wToken) from the platform balance. Now, we can specify if we want to do so or not