### PR TITLE
feat: store position ids

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -23,6 +23,8 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   /// @inheritdoc IDCAFeeManager
   mapping(bytes32 => uint256) public positions; // key(from, to) => position id
 
+  mapping(address => uint256[]) internal _positionsWithToken; // token address => all positions with address as to
+
   constructor(
     IDCAHub _hub,
     IWrappedProtocolToken _wToken,
@@ -133,24 +135,24 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   function availableBalances(address[] calldata _tokens) external view returns (AvailableBalance[] memory _balances) {
     _balances = new AvailableBalance[](_tokens.length);
     for (uint256 i; i < _tokens.length; i++) {
+      address _token = _tokens[i];
+      uint256[] memory _positionIds = _positionsWithToken[_token];
+      PositionBalance[] memory _positions = new PositionBalance[](_positionIds.length);
+      for (uint256 j; j < _positionIds.length; j++) {
+        IDCAHubPositionHandler.UserPosition memory _userPosition = hub.userPosition(_positionIds[j]);
+        _positions[j] = PositionBalance({
+          positionId: _positionIds[j],
+          from: _userPosition.from,
+          to: _userPosition.to,
+          swapped: _userPosition.swapped,
+          remaining: _userPosition.remaining
+        });
+      }
       _balances[i] = AvailableBalance({
-        token: _tokens[i],
-        platformBalance: hub.platformBalance(_tokens[i]),
-        feeManagerBalance: IERC20(_tokens[i]).balanceOf(address(this))
-      });
-    }
-  }
-
-  /// @inheritdoc IDCAFeeManager
-  function positionBalances(uint256[] calldata _positionIds) external view returns (PositionBalance[] memory _balances) {
-    _balances = new PositionBalance[](_positionIds.length);
-    for (uint256 i; i < _positionIds.length; i++) {
-      IDCAHubPositionHandler.UserPosition memory _userPosition = hub.userPosition(_positionIds[i]);
-      _balances[i] = PositionBalance({
-        positionId: _positionIds[i],
-        from: _userPosition.from,
-        to: _userPosition.to,
-        swappedBalance: _userPosition.swapped
+        token: _token,
+        platformBalance: hub.platformBalance(_token),
+        feeManagerBalance: IERC20(_token).balanceOf(address(this)),
+        positions: _positions
       });
     }
   }
@@ -180,6 +182,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
         uint256 _newPositionId
       ) {
         positions[_key] = _newPositionId;
+        _positionsWithToken[_to].push(_newPositionId);
       } catch {
         _failed = true;
       }

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -37,6 +37,7 @@ interface IDCAFeeManager is IGovernable {
     address token;
     uint256 platformBalance;
     uint256 feeManagerBalance;
+    PositionBalance[] positions;
   }
 
   /// @notice Represents information about a specific position
@@ -44,7 +45,8 @@ interface IDCAFeeManager is IGovernable {
     uint256 positionId;
     IERC20Metadata from;
     IERC20Metadata to;
-    uint256 swappedBalance;
+    uint256 swapped;
+    uint256 remaining;
   }
 
   /// @notice Thrown when a user tries to execute a permissioned action without the access to do so
@@ -180,12 +182,4 @@ interface IDCAFeeManager is IGovernable {
    * @return How much is available for withdraw, for the given tokens
    */
   function availableBalances(address[] calldata tokens) external view returns (AvailableBalance[] memory);
-
-  /**
-   * @notice Returns how much is available for withdraw, for the given positions
-   * @dev This is meant for off-chan purposes
-   * @param positionIds The positions to check the balance for
-   * @return How much is available for withdraw, for the given positions
-   */
-  function positionBalances(uint256[] calldata positionIds) external view returns (PositionBalance[] memory);
 }

--- a/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
@@ -17,4 +17,14 @@ contract DCAFeeManagerMock is DCAFeeManager {
   ) external {
     positions[getPositionKey(_from, _to)] = _positionId;
   }
+
+  function positionsWithToken(address _toToken) external view returns (uint256[] memory) {
+    return _positionsWithToken[_toToken];
+  }
+
+  function setPositionsWithToken(address _toToken, uint256[] calldata _positionIds) external {
+    for (uint256 i; i < _positionIds.length; i++) {
+      _positionsWithToken[_toToken].push(_positionIds[i]);
+    }
+  }
 }

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -99,6 +99,7 @@ contract('DCAFeeManager', () => {
     expect(usdcBalance.feeManagerBalance).to.equal(0);
     expect(wbtcBalance.platformBalance).to.equal(0);
     expect(wbtcBalance.feeManagerBalance.gt(0)).to.be.true;
+    expect(wbtcBalance.positions).to.have.lengthOf(0);
 
     // Prepare data to withdraw USDC from platform balance
     const { data: withdrawData } = await DCAFeeManager.populateTransaction.withdrawFromPlatformBalance(
@@ -121,29 +122,31 @@ contract('DCAFeeManager', () => {
     // Execute swap
     await swap({ from: USDC, to: WETH }, { from: WBTC, to: WETH });
 
-    // Check position balances
-    const [position2, position3] = await DCAFeeManager.positionBalances([2, 3]);
-    expect(position2.from.toLowerCase()).to.equal(USDC.address.toLowerCase());
-    expect(position2.to.toLowerCase()).to.eql(WETH.address.toLowerCase());
-    expect(position2.swappedBalance.gt(0)).to.be.true;
-    expect(position3.from.toLowerCase()).to.equal(WBTC.address.toLowerCase());
-    expect(position3.to.toLowerCase()).to.equal(WETH.address.toLowerCase());
-    expect(position3.swappedBalance.gt(0)).to.be.true;
-
-    // Check platform balance
-    const wethPlatformBalance = await DCAHub.platformBalance(WETH.address);
-    expect(wethPlatformBalance.gt(0)).to.be.true;
+    // Check balances
+    const [wethBalance] = await DCAFeeManager.availableBalances([WETH.address]);
+    expect(wethBalance.platformBalance.gt(0)).to.be.true;
+    expect(wethBalance.positions).to.have.lengthOf(2);
+    const [position1, position2] = wethBalance.positions;
+    expect(position1.from.toLowerCase()).to.equal(USDC.address.toLowerCase());
+    expect(position1.to.toLowerCase()).to.eql(WETH.address.toLowerCase());
+    expect(position1.swapped.gt(0)).to.be.true;
+    expect(position1.remaining).to.equal(0);
+    expect(position2.from.toLowerCase()).to.equal(WBTC.address.toLowerCase());
+    expect(position2.to.toLowerCase()).to.equal(WETH.address.toLowerCase());
+    expect(position2.swapped.gt(0)).to.be.true;
+    expect(position2.remaining).to.equal(0);
 
     // Execute withdraw as protocol token
-    await DCAFeeManager.connect(allowed).withdrawProtocolToken(true, [2, 3], RECIPIENT);
+    await DCAFeeManager.connect(allowed).withdrawProtocolToken(true, [position1.positionId, position2.positionId], RECIPIENT);
 
     // Make sure that everything was transferred to recipient
     const recipientBalance = await ethers.provider.getBalance(RECIPIENT);
-    const [position2After, position3After] = await DCAFeeManager.positionBalances([2, 3]);
-    expect(recipientBalance).to.equal(wethPlatformBalance.add(position2.swappedBalance).add(position3.swappedBalance));
-    expect(position2After.swappedBalance).to.equal(0);
-    expect(position3After.swappedBalance).to.equal(0);
-    expect(await DCAHub.platformBalance(WETH.address)).to.equal(0);
+    const [wethBalanceAfter] = await DCAFeeManager.availableBalances([WETH.address]);
+    expect(wethBalanceAfter.platformBalance).to.equal(0);
+    const [position1After, position2After] = wethBalanceAfter.positions;
+    expect(recipientBalance).to.equal(wethBalance.platformBalance.add(position1.swapped).add(position2.swapped));
+    expect(position1After.swapped).to.equal(0);
+    expect(position2After.swapped).to.equal(0);
   });
 
   async function distributeTokensToUsers() {


### PR DESCRIPTION
We are now making a small change where we store all created positions in an array. This will allow us to return all position when `availableBalances` is called, and therefore there will be no need for an off-chain way to find the positions.

This should make the entire UX much easier to use.

Also, since we can return everything in `availableBalances`, we removed `positionBalances`