### PR TITLE
refactor: take hub address withdraw platform balance

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -40,8 +40,12 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   }
 
   /// @inheritdoc IDCAFeeManager
-  function withdrawFromPlatformBalance(IDCAHub.AmountOfToken[] calldata _amountToWithdraw, address _recipient) external onlyOwnerOrAllowed {
-    hub.withdrawFromPlatformBalance(_amountToWithdraw, _recipient);
+  function withdrawFromPlatformBalance(
+    IDCAHub _hub,
+    IDCAHub.AmountOfToken[] calldata _amountToWithdraw,
+    address _recipient
+  ) external onlyOwnerOrAllowed {
+    _hub.withdrawFromPlatformBalance(_amountToWithdraw, _recipient);
   }
 
   /// @inheritdoc IDCAFeeManager

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -114,10 +114,15 @@ interface IDCAFeeManager is IGovernable {
   /**
    * @notice Withdraws tokens from the platform balance, and sends them to the given recipient
    * @dev Can only be executed by the owner or allowed users
+   * @param hub The address of the DCAHub
    * @param amountToWithdraw The tokens to withdraw, and their amounts
    * @param recipient The address of the recipient
    */
-  function withdrawFromPlatformBalance(IDCAHub.AmountOfToken[] calldata amountToWithdraw, address recipient) external;
+  function withdrawFromPlatformBalance(
+    IDCAHub hub,
+    IDCAHub.AmountOfToken[] calldata amountToWithdraw,
+    address recipient
+  ) external;
 
   /**
    * @notice Withdraws tokens from the contract's balance, and sends them to the given recipient

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -114,7 +114,7 @@ interface IDCAFeeManager is IGovernable {
   /**
    * @notice Withdraws tokens from the platform balance, and sends them to the given recipient
    * @dev Can only be executed by the owner or allowed users
-   * @param hub The address of the DCAHub
+   * @param hub The address of the DCA Hub
    * @param amountToWithdraw The tokens to withdraw, and their amounts
    * @param recipient The address of the recipient
    */

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -76,13 +76,6 @@ interface IDCAFeeManager is IGovernable {
   function SWAP_INTERVAL() external view returns (uint32);
 
   /**
-   * @notice Returns address for the DCA Hub
-   * @dev This value cannot be modified after deployment
-   * @return The address for the DCA Hub
-   */
-  function hub() external view returns (IDCAHub);
-
-  /**
    * @notice Returns address for the wToken
    * @dev This value cannot be modified after deployment
    * @return The address for the wToken
@@ -135,10 +128,15 @@ interface IDCAFeeManager is IGovernable {
   /**
    * @notice Withdraws tokens from the given positions, and sends them to the given recipient
    * @dev Can only be executed by the owner or allowed users
+   * @param hub The address of the DCA Hub
    * @param positionSets The positions to withdraw from
    * @param recipient The address of the recipient
    */
-  function withdrawFromPositions(IDCAHub.PositionSet[] calldata positionSets, address recipient) external;
+  function withdrawFromPositions(
+    IDCAHub hub,
+    IDCAHub.PositionSet[] calldata positionSets,
+    address recipient
+  ) external;
 
   /**
    * @notice Withdraws protocol tokens and sends them to the given recipient
@@ -152,20 +150,30 @@ interface IDCAFeeManager is IGovernable {
    * @notice Takes a certain amount of the given tokens, and sets up DCA swaps for each of them.
    *         The given amounts can be distributed across different target tokens
    * @dev Can only be executed by the owner or allowed users
+   * @param hub The address of the DCA Hub
    * @param amounts Specific tokens and amounts to take from this contract and send to the hub
    * @param distribution How to distribute the source tokens across different target tokens
    */
-  function fillPositions(AmountToFill[] calldata amounts, TargetTokenShare[] calldata distribution) external;
+  function fillPositions(
+    IDCAHub hub,
+    AmountToFill[] calldata amounts,
+    TargetTokenShare[] calldata distribution
+  ) external;
 
   /**
    * @notice Takes list of position ids and terminates them. All swapped and unswapped balance is
    *         sent to the given recipient. This is meant to be used only if for some reason swaps are
    *         no longer executed
    * @dev Can only be executed by the owner or allowed users
+   * @param hub The address of the DCA Hub
    * @param positionIds The positions to terminate
    * @param recipient The address that will receive all swapped and unswapped tokens
    */
-  function terminatePositions(uint256[] calldata positionIds, address recipient) external;
+  function terminatePositions(
+    IDCAHub hub,
+    uint256[] calldata positionIds,
+    address recipient
+  ) external;
 
   /**
    * @notice Gives or takes access to permissioned actions from users
@@ -175,16 +183,11 @@ interface IDCAFeeManager is IGovernable {
   function setAccess(UserAccess[] calldata access) external;
 
   /**
-   * @notice Sets the maximum allowance to the DCA Hub, for the given token
-   * @param token The token to set the allowance for
-   */
-  function resetAllowance(IERC20 token) external;
-
-  /**
    * @notice Returns how much is available for withdraw, for the given tokens
    * @dev This is meant for off-chan purposes
+   * @param hub The address of the DCA Hub
    * @param tokens The tokens to check the balance for
    * @return How much is available for withdraw, for the given tokens
    */
-  function availableBalances(address[] calldata tokens) external view returns (AvailableBalance[] memory);
+  function availableBalances(IDCAHub hub, address[] calldata tokens) external view returns (AvailableBalance[] memory);
 }

--- a/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
@@ -4,11 +4,7 @@ pragma solidity >=0.8.7 <0.9.0;
 import '../../DCAFeeManager/DCAFeeManager.sol';
 
 contract DCAFeeManagerMock is DCAFeeManager {
-  constructor(
-    IDCAHub _hub,
-    IWrappedProtocolToken _wToken,
-    address _governor
-  ) DCAFeeManager(_hub, _wToken, _governor) {}
+  constructor(IWrappedProtocolToken _wToken, address _governor) DCAFeeManager(_wToken, _governor) {}
 
   function setPosition(
     address _from,

--- a/deploy/005_fee_manager.ts
+++ b/deploy/005_fee_manager.ts
@@ -34,8 +34,6 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
       throw new Error(`Unsupported chain '${hre.network.name}`);
   }
 
-  const hub = await hre.deployments.get('DCAHub');
-
   await deployThroughDeterministicFactory({
     deployer,
     name: 'DCAFeeManager',
@@ -43,8 +41,8 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     contract: 'contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager',
     bytecode: DCAFeeManager__factory.bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address'],
-      values: [hub.address, wProtocolToken, governor],
+      types: ['address', 'address'],
+      values: [wProtocolToken, governor],
     },
     log: !process.env.TEST,
   });

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -103,6 +103,7 @@ contract('DCAFeeManager', () => {
 
     // Prepare data to withdraw USDC from platform balance
     const { data: withdrawData } = await DCAFeeManager.populateTransaction.withdrawFromPlatformBalance(
+      DCAHub.address,
       [{ token: USDC.address, amount: usdcBalance.platformBalance }],
       DCAFeeManager.address
     );
@@ -139,6 +140,7 @@ contract('DCAFeeManager', () => {
     // Execute withdraw as protocol token
     const total = wethBalance.platformBalance.add(wethBalance.positions[0].swapped).add(wethBalance.positions[1].swapped);
     const { data: withdrawPlatformBalanceData } = await DCAFeeManager.populateTransaction.withdrawFromPlatformBalance(
+      DCAHub.address,
       [{ token: WETH.address, amount: wethBalance.platformBalance }],
       DCAFeeManager.address
     );

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -94,7 +94,7 @@ contract('DCAFeeManager', () => {
     await swap({ from: WBTC, to: USDC });
 
     // Calculate and verify balances
-    const [usdcBalance, wbtcBalance] = await DCAFeeManager.availableBalances([USDC.address, WBTC.address]);
+    const [usdcBalance, wbtcBalance] = await DCAFeeManager.availableBalances(DCAHub.address, [USDC.address, WBTC.address]);
     expect(usdcBalance.platformBalance.gt(0)).to.be.true;
     expect(usdcBalance.feeManagerBalance).to.equal(0);
     expect(wbtcBalance.platformBalance).to.equal(0);
@@ -110,6 +110,7 @@ contract('DCAFeeManager', () => {
 
     // Prepare data to send WBTC and USDC to Hub, to DCA for WETH
     const { data: fillData } = await DCAFeeManager.populateTransaction.fillPositions(
+      DCAHub.address,
       [
         { token: USDC.address, amount: usdcBalance.platformBalance, amountOfSwaps: 1 },
         { token: WBTC.address, amount: wbtcBalance.feeManagerBalance, amountOfSwaps: 1 },
@@ -124,7 +125,7 @@ contract('DCAFeeManager', () => {
     await swap({ from: USDC, to: WETH }, { from: WBTC, to: WETH });
 
     // Check balances
-    const [wethBalance] = await DCAFeeManager.availableBalances([WETH.address]);
+    const [wethBalance] = await DCAFeeManager.availableBalances(DCAHub.address, [WETH.address]);
     expect(wethBalance.platformBalance.gt(0)).to.be.true;
     expect(wethBalance.positions).to.have.lengthOf(2);
     const [position1, position2] = wethBalance.positions;
@@ -145,6 +146,7 @@ contract('DCAFeeManager', () => {
       DCAFeeManager.address
     );
     const { data: withdrawPositionsData } = await DCAFeeManager.populateTransaction.withdrawFromPositions(
+      DCAHub.address,
       [{ token: WETH.address, positionIds: [position1.positionId, position2.positionId] }],
       DCAFeeManager.address
     );
@@ -159,7 +161,7 @@ contract('DCAFeeManager', () => {
 
     // Make sure that everything was transferred to recipient
     const recipientBalance = await ethers.provider.getBalance(RECIPIENT);
-    const [wethBalanceAfter] = await DCAFeeManager.availableBalances([WETH.address]);
+    const [wethBalanceAfter] = await DCAFeeManager.availableBalances(DCAHub.address, [WETH.address]);
     expect(wethBalanceAfter.platformBalance).to.equal(0);
     const [position1After, position2After] = wethBalanceAfter.positions;
     expect(recipientBalance).to.equal(wethBalance.platformBalance.add(position1.swapped).add(position2.swapped));

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -45,7 +45,7 @@ contract('DCAFeeManager', () => {
     wToken = await wTokenFactory.deploy('WETH', 'WETH', 18);
     await setProtocolBalance(wToken, utils.parseEther('100'));
     DCAFeeManagerFactory = await ethers.getContractFactory('contracts/mocks/DCAFeeManager/DCAFeeManager.sol:DCAFeeManagerMock');
-    DCAFeeManager = await DCAFeeManagerFactory.deploy(DCAHub.address, wToken.address, governor.address);
+    DCAFeeManager = await DCAFeeManagerFactory.deploy(wToken.address, governor.address);
     snapshotId = await snapshot.take();
   });
 
@@ -64,9 +64,6 @@ contract('DCAFeeManager', () => {
 
   describe('constructor', () => {
     when('contract is initiated', () => {
-      then('hub is set correctly', async () => {
-        expect(await DCAFeeManager.hub()).to.equal(DCAHub.address);
-      });
       then('max token total share is set correctly', async () => {
         expect(await DCAFeeManager.MAX_TOKEN_TOTAL_SHARE()).to.equal(MAX_SHARES);
       });
@@ -141,7 +138,7 @@ contract('DCAFeeManager', () => {
     when('withdraw is executed', () => {
       const POSITION_SETS = [{ token: TOKEN_A, positionIds: [1, 2, 3] }];
       given(async () => {
-        await DCAFeeManager.connect(governor).withdrawFromPositions(POSITION_SETS, RECIPIENT);
+        await DCAFeeManager.connect(governor).withdrawFromPositions(DCAHub.address, POSITION_SETS, RECIPIENT);
       });
       then('hub is called correctly', () => {
         expect(DCAHub.withdrawSwappedMany).to.have.been.calledOnce;
@@ -152,7 +149,7 @@ contract('DCAFeeManager', () => {
     });
     shouldOnlyBeExecutableByGovernorOrAllowed({
       funcAndSignature: 'withdrawFromPositions',
-      params: [[], RECIPIENT],
+      params: () => [DCAHub.address, [], RECIPIENT],
     });
   });
 
@@ -192,6 +189,7 @@ contract('DCAFeeManager', () => {
       given(async () => {
         erc20Token.allowance.returns(0);
         await DCAFeeManager.connect(governor).fillPositions(
+          DCAHub.address,
           [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
           DISTRIBUTION
         );
@@ -200,12 +198,29 @@ contract('DCAFeeManager', () => {
         expect(erc20Token.approve).to.have.been.calledOnceWith(DCAHub.address, constants.MaxUint256);
       });
     });
+    when('allowance is not zero but less than needed', () => {
+      given(async () => {
+        erc20Token.allowance.returns(1);
+        await DCAFeeManager.connect(governor).fillPositions(
+          DCAHub.address,
+          [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
+          DISTRIBUTION
+        );
+      });
+      then('allowance is reset', () => {
+        expect(erc20Token.approve).to.have.been.calledTwice;
+        expect(erc20Token.approve).to.have.been.calledWith(DCAHub.address, 0);
+        expect(erc20Token.approve).to.have.been.calledWith(DCAHub.address, constants.MaxUint256);
+      });
+    });
     when('there is no position created', () => {
       describe('and deposit fails', () => {
         given(async () => {
+          erc20Token.allowance.returns(constants.MaxUint256);
           DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].revertsAtCall(0);
           DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].returnsAtCall(1, POSITION_ID_TOKEN_B);
           await DCAFeeManager.connect(governor).fillPositions(
+            DCAHub.address,
             [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
             DISTRIBUTION
           );
@@ -230,12 +245,16 @@ contract('DCAFeeManager', () => {
           const positions = await DCAFeeManager.positionsWithToken(TOKEN_B);
           expect(positions).to.eql([BigNumber.from(POSITION_ID_TOKEN_B)]);
         });
+        then('allowance is not set', () => {
+          expect(erc20Token.approve).to.not.have.been.called;
+        });
       });
       describe('and deposit works', () => {
         given(async () => {
           DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].returnsAtCall(0, POSITION_ID_TOKEN_A);
           DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].returnsAtCall(1, POSITION_ID_TOKEN_B);
           await DCAFeeManager.connect(governor).fillPositions(
+            DCAHub.address,
             [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
             DISTRIBUTION
           );
@@ -293,6 +312,7 @@ contract('DCAFeeManager', () => {
         given(async () => {
           DCAHub.increasePosition.revertsAtCall(0);
           await DCAFeeManager.connect(governor).fillPositions(
+            DCAHub.address,
             [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
             DISTRIBUTION
           );
@@ -305,6 +325,7 @@ contract('DCAFeeManager', () => {
       describe('and increase works', () => {
         given(async () => {
           await DCAFeeManager.connect(governor).fillPositions(
+            DCAHub.address,
             [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
             DISTRIBUTION
           );
@@ -323,7 +344,7 @@ contract('DCAFeeManager', () => {
 
     shouldOnlyBeExecutableByGovernorOrAllowed({
       funcAndSignature: 'fillPositions',
-      params: () => [[{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }], DISTRIBUTION],
+      params: () => [DCAHub.address, [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }], DISTRIBUTION],
     });
   });
 
@@ -344,7 +365,7 @@ contract('DCAFeeManager', () => {
         }));
         await DCAFeeManager.setPosition(erc20Token.address, TOKEN_A, 1);
         await DCAFeeManager.setPosition(erc20Token.address, TOKEN_B, 2);
-        await DCAFeeManager.connect(governor).terminatePositions(POSITION_IDS, RECIPIENT);
+        await DCAFeeManager.connect(governor).terminatePositions(DCAHub.address, POSITION_IDS, RECIPIENT);
       });
       then('position 1 is terminated and deleted from fee manager', async () => {
         expect(DCAHub.terminate).to.have.been.calledWith(1, RECIPIENT, RECIPIENT);
@@ -362,7 +383,7 @@ contract('DCAFeeManager', () => {
     });
     shouldOnlyBeExecutableByGovernorOrAllowed({
       funcAndSignature: 'terminatePositions',
-      params: [[], RECIPIENT],
+      params: () => [DCAHub.address, [], RECIPIENT],
     });
   });
 
@@ -411,19 +432,6 @@ contract('DCAFeeManager', () => {
     });
   });
 
-  describe('resetAllowance', () => {
-    when('function is executed', () => {
-      given(async () => {
-        await DCAFeeManager.resetAllowance(erc20Token.address);
-      });
-      then('allowance is reset', async () => {
-        expect(erc20Token.approve).to.have.been.calledTwice;
-        expect(erc20Token.approve).to.have.been.calledWith(DCAHub.address, 0);
-        expect(erc20Token.approve).to.have.been.calledWith(DCAHub.address, constants.MaxUint256);
-      });
-    });
-  });
-
   describe('availableBalances', () => {
     when('function is executed', () => {
       const PLATFORM_BALANCE = utils.parseEther('1');
@@ -438,7 +446,7 @@ contract('DCAFeeManager', () => {
         await DCAFeeManager.setPositionsWithToken(erc20Token.address, [1, 2]);
       });
       then('balances are returned correctly', async () => {
-        const balances = await DCAFeeManager.availableBalances([erc20Token.address]);
+        const balances = await DCAFeeManager.availableBalances(DCAHub.address, [erc20Token.address]);
         expect(balances).to.have.lengthOf(1);
         expect(balances[0].token).to.equal(erc20Token.address);
         expect(balances[0].platformBalance).to.equal(PLATFORM_BALANCE);

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -103,7 +103,7 @@ contract('DCAFeeManager', () => {
     when('withdraw is executed', () => {
       const AMOUNT_TO_WITHDRAW = [{ token: TOKEN_A, amount: utils.parseEther('1') }];
       given(async () => {
-        await DCAFeeManager.connect(governor).withdrawFromPlatformBalance(AMOUNT_TO_WITHDRAW, RECIPIENT);
+        await DCAFeeManager.connect(governor).withdrawFromPlatformBalance(DCAHub.address, AMOUNT_TO_WITHDRAW, RECIPIENT);
       });
       then('hub is called correctly', () => {
         expect(DCAHub.withdrawFromPlatformBalance).to.have.been.calledOnce;
@@ -114,7 +114,7 @@ contract('DCAFeeManager', () => {
     });
     shouldOnlyBeExecutableByGovernorOrAllowed({
       funcAndSignature: 'withdrawFromPlatformBalance',
-      params: [[], RECIPIENT],
+      params: () => [DCAHub.address, [], RECIPIENT],
     });
   });
 


### PR DESCRIPTION
The Fee Manager currently takes a DCAHub address on the constructor. Since it's immutable, it cannot be changed. We could make it mutable, but that would make all actions more expensive

The idea is to add the hub as a parameter to all actions, so that the same Fee Manager can work for multiple hubs at the same time