### PR TITLE
refactor: handle allowance reset internally

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -15,8 +15,6 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   /// @inheritdoc IDCAFeeManager
   uint32 public constant SWAP_INTERVAL = 1 days;
   /// @inheritdoc IDCAFeeManager
-  IDCAHub public immutable hub;
-  /// @inheritdoc IDCAFeeManager
   IWrappedProtocolToken public immutable wToken;
   /// @inheritdoc IDCAFeeManager
   mapping(address => bool) public hasAccess;
@@ -25,12 +23,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
 
   mapping(address => uint256[]) internal _positionsWithToken; // token address => all positions with address as to
 
-  constructor(
-    IDCAHub _hub,
-    IWrappedProtocolToken _wToken,
-    address _governor
-  ) Governable(_governor) {
-    hub = _hub;
+  constructor(IWrappedProtocolToken _wToken, address _governor) Governable(_governor) {
     wToken = _wToken;
   }
 
@@ -56,8 +49,12 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   }
 
   /// @inheritdoc IDCAFeeManager
-  function withdrawFromPositions(IDCAHub.PositionSet[] calldata _positionSets, address _recipient) external onlyOwnerOrAllowed {
-    hub.withdrawSwappedMany(_positionSets, _recipient);
+  function withdrawFromPositions(
+    IDCAHub _hub,
+    IDCAHub.PositionSet[] calldata _positionSets,
+    address _recipient
+  ) external onlyOwnerOrAllowed {
+    _hub.withdrawSwappedMany(_positionSets, _recipient);
   }
 
   /// @inheritdoc IDCAFeeManager
@@ -66,17 +63,21 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   }
 
   /// @inheritdoc IDCAFeeManager
-  function fillPositions(AmountToFill[] calldata _amounts, TargetTokenShare[] calldata _distribution) external onlyOwnerOrAllowed {
+  function fillPositions(
+    IDCAHub _hub,
+    AmountToFill[] calldata _amounts,
+    TargetTokenShare[] calldata _distribution
+  ) external onlyOwnerOrAllowed {
     for (uint256 i; i < _amounts.length; i++) {
       AmountToFill memory _amount = _amounts[i];
 
-      uint256 _allowance = IERC20(_amount.token).allowance(address(this), address(hub));
+      uint256 _allowance = IERC20(_amount.token).allowance(address(this), address(_hub));
       if (_allowance < _amount.amount) {
         if (_allowance > 0) {
-          IERC20(_amount.token).approve(address(hub), 0); // We do this first because some tokens (like USDT) will fail if we don't
+          IERC20(_amount.token).approve(address(_hub), 0); // We do this first because some tokens (like USDT) will fail if we don't
         }
         // Approve the token so that the hub can take the funds
-        IERC20(_amount.token).approve(address(hub), type(uint256).max);
+        IERC20(_amount.token).approve(address(_hub), type(uint256).max);
       }
 
       // Distribute to different tokens
@@ -86,7 +87,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
           ? (_amount.amount * _distribution[j].shares) / MAX_TOKEN_TOTAL_SHARE
           : _amount.amount - _amountSpent; // If this is the last token, then assign everything that hasn't been spent. We do this to prevent unspent tokens due to rounding errors
 
-        bool _failed = _depositToHub(_amount.token, _distribution[j].token, _amountToDeposit, _amount.amountOfSwaps);
+        bool _failed = _depositToHub(_hub, _amount.token, _distribution[j].token, _amountToDeposit, _amount.amountOfSwaps);
         if (!_failed) {
           _amountSpent += _amountToDeposit;
         }
@@ -95,11 +96,15 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   }
 
   /// @inheritdoc IDCAFeeManager
-  function terminatePositions(uint256[] calldata _positionIds, address _recipient) external onlyOwnerOrAllowed {
+  function terminatePositions(
+    IDCAHub _hub,
+    uint256[] calldata _positionIds,
+    address _recipient
+  ) external onlyOwnerOrAllowed {
     for (uint256 i; i < _positionIds.length; i++) {
       uint256 _positionId = _positionIds[i];
-      IDCAHubPositionHandler.UserPosition memory _position = hub.userPosition(_positionId);
-      hub.terminate(_positionId, _recipient, _recipient);
+      IDCAHubPositionHandler.UserPosition memory _position = _hub.userPosition(_positionId);
+      _hub.terminate(_positionId, _recipient, _recipient);
       delete positions[getPositionKey(address(_position.from), address(_position.to))];
     }
   }
@@ -113,14 +118,14 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   }
 
   /// @inheritdoc IDCAFeeManager
-  function availableBalances(address[] calldata _tokens) external view returns (AvailableBalance[] memory _balances) {
+  function availableBalances(IDCAHub _hub, address[] calldata _tokens) external view returns (AvailableBalance[] memory _balances) {
     _balances = new AvailableBalance[](_tokens.length);
     for (uint256 i; i < _tokens.length; i++) {
       address _token = _tokens[i];
       uint256[] memory _positionIds = _positionsWithToken[_token];
       PositionBalance[] memory _positions = new PositionBalance[](_positionIds.length);
       for (uint256 j; j < _positionIds.length; j++) {
-        IDCAHubPositionHandler.UserPosition memory _userPosition = hub.userPosition(_positionIds[j]);
+        IDCAHubPositionHandler.UserPosition memory _userPosition = _hub.userPosition(_positionIds[j]);
         _positions[j] = PositionBalance({
           positionId: _positionIds[j],
           from: _userPosition.from,
@@ -131,7 +136,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
       }
       _balances[i] = AvailableBalance({
         token: _token,
-        platformBalance: hub.platformBalance(_token),
+        platformBalance: _hub.platformBalance(_token),
         feeManagerBalance: IERC20(_token).balanceOf(address(this)),
         positions: _positions
       });
@@ -145,6 +150,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   receive() external payable {}
 
   function _depositToHub(
+    IDCAHub _hub,
     address _from,
     address _to,
     uint256 _amount,
@@ -159,7 +165,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
 
     if (_positionId == 0) {
       // If position doesn't exist, then try to create it
-      try hub.deposit(_from, _to, _amount, _amountOfSwaps, SWAP_INTERVAL, address(this), new IDCAPermissionManager.PermissionSet[](0)) returns (
+      try _hub.deposit(_from, _to, _amount, _amountOfSwaps, SWAP_INTERVAL, address(this), new IDCAPermissionManager.PermissionSet[](0)) returns (
         uint256 _newPositionId
       ) {
         positions[_key] = _newPositionId;
@@ -169,7 +175,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
       }
     } else {
       // If position exists, then try to increase it
-      try hub.increasePosition(_positionId, _amount, _amountOfSwaps) {} catch {
+      try _hub.increasePosition(_positionId, _amount, _amountOfSwaps) {} catch {
         _failed = true;
       }
     }

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -76,13 +76,6 @@ interface IDCAFeeManager is IGovernable {
   function SWAP_INTERVAL() external view returns (uint32);
 
   /**
-   * @notice Returns address for the DCA Hub
-   * @dev This value cannot be modified after deployment
-   * @return The address for the DCA Hub
-   */
-  function hub() external view returns (IDCAHub);
-
-  /**
    * @notice Returns address for the wToken
    * @dev This value cannot be modified after deployment
    * @return The address for the wToken
@@ -135,10 +128,15 @@ interface IDCAFeeManager is IGovernable {
   /**
    * @notice Withdraws tokens from the given positions, and sends them to the given recipient
    * @dev Can only be executed by the owner or allowed users
+   * @param hub The address of the DCA Hub
    * @param positionSets The positions to withdraw from
    * @param recipient The address of the recipient
    */
-  function withdrawFromPositions(IDCAHub.PositionSet[] calldata positionSets, address recipient) external;
+  function withdrawFromPositions(
+    IDCAHub hub,
+    IDCAHub.PositionSet[] calldata positionSets,
+    address recipient
+  ) external;
 
   /**
    * @notice Withdraws protocol tokens and sends them to the given recipient
@@ -152,20 +150,30 @@ interface IDCAFeeManager is IGovernable {
    * @notice Takes a certain amount of the given tokens, and sets up DCA swaps for each of them.
    *         The given amounts can be distributed across different target tokens
    * @dev Can only be executed by the owner or allowed users
+   * @param hub The address of the DCA Hub
    * @param amounts Specific tokens and amounts to take from this contract and send to the hub
    * @param distribution How to distribute the source tokens across different target tokens
    */
-  function fillPositions(AmountToFill[] calldata amounts, TargetTokenShare[] calldata distribution) external;
+  function fillPositions(
+    IDCAHub hub,
+    AmountToFill[] calldata amounts,
+    TargetTokenShare[] calldata distribution
+  ) external;
 
   /**
    * @notice Takes list of position ids and terminates them. All swapped and unswapped balance is
    *         sent to the given recipient. This is meant to be used only if for some reason swaps are
    *         no longer executed
    * @dev Can only be executed by the owner or allowed users
+   * @param hub The address of the DCA Hub
    * @param positionIds The positions to terminate
    * @param recipient The address that will receive all swapped and unswapped tokens
    */
-  function terminatePositions(uint256[] calldata positionIds, address recipient) external;
+  function terminatePositions(
+    IDCAHub hub,
+    uint256[] calldata positionIds,
+    address recipient
+  ) external;
 
   /**
    * @notice Gives or takes access to permissioned actions from users
@@ -177,8 +185,9 @@ interface IDCAFeeManager is IGovernable {
   /**
    * @notice Returns how much is available for withdraw, for the given tokens
    * @dev This is meant for off-chan purposes
+   * @param hub The address of the DCA Hub
    * @param tokens The tokens to check the balance for
    * @return How much is available for withdraw, for the given tokens
    */
-  function availableBalances(address[] calldata tokens) external view returns (AvailableBalance[] memory);
+  function availableBalances(IDCAHub hub, address[] calldata tokens) external view returns (AvailableBalance[] memory);
 }

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -175,12 +175,6 @@ interface IDCAFeeManager is IGovernable {
   function setAccess(UserAccess[] calldata access) external;
 
   /**
-   * @notice Sets the maximum allowance to the DCA Hub, for the given token
-   * @param token The token to set the allowance for
-   */
-  function resetAllowance(IERC20 token) external;
-
-  /**
    * @notice Returns how much is available for withdraw, for the given tokens
    * @dev This is meant for off-chan purposes
    * @param tokens The tokens to check the balance for

--- a/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
@@ -4,11 +4,7 @@ pragma solidity >=0.8.7 <0.9.0;
 import '../../DCAFeeManager/DCAFeeManager.sol';
 
 contract DCAFeeManagerMock is DCAFeeManager {
-  constructor(
-    IDCAHub _hub,
-    IWrappedProtocolToken _wToken,
-    address _governor
-  ) DCAFeeManager(_hub, _wToken, _governor) {}
+  constructor(IWrappedProtocolToken _wToken, address _governor) DCAFeeManager(_wToken, _governor) {}
 
   function setPosition(
     address _from,

--- a/deploy/005_fee_manager.ts
+++ b/deploy/005_fee_manager.ts
@@ -34,8 +34,6 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
       throw new Error(`Unsupported chain '${hre.network.name}`);
   }
 
-  const hub = await hre.deployments.get('DCAHub');
-
   await deployThroughDeterministicFactory({
     deployer,
     name: 'DCAFeeManager',
@@ -43,8 +41,8 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     contract: 'contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager',
     bytecode: DCAFeeManager__factory.bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address'],
-      values: [hub.address, wProtocolToken, governor],
+      types: ['address', 'address'],
+      values: [wProtocolToken, governor],
     },
     log: !process.env.TEST,
   });

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -94,7 +94,7 @@ contract('DCAFeeManager', () => {
     await swap({ from: WBTC, to: USDC });
 
     // Calculate and verify balances
-    const [usdcBalance, wbtcBalance] = await DCAFeeManager.availableBalances([USDC.address, WBTC.address]);
+    const [usdcBalance, wbtcBalance] = await DCAFeeManager.availableBalances(DCAHub.address, [USDC.address, WBTC.address]);
     expect(usdcBalance.platformBalance.gt(0)).to.be.true;
     expect(usdcBalance.feeManagerBalance).to.equal(0);
     expect(wbtcBalance.platformBalance).to.equal(0);
@@ -110,6 +110,7 @@ contract('DCAFeeManager', () => {
 
     // Prepare data to send WBTC and USDC to Hub, to DCA for WETH
     const { data: fillData } = await DCAFeeManager.populateTransaction.fillPositions(
+      DCAHub.address,
       [
         { token: USDC.address, amount: usdcBalance.platformBalance, amountOfSwaps: 1 },
         { token: WBTC.address, amount: wbtcBalance.feeManagerBalance, amountOfSwaps: 1 },
@@ -124,7 +125,7 @@ contract('DCAFeeManager', () => {
     await swap({ from: USDC, to: WETH }, { from: WBTC, to: WETH });
 
     // Check balances
-    const [wethBalance] = await DCAFeeManager.availableBalances([WETH.address]);
+    const [wethBalance] = await DCAFeeManager.availableBalances(DCAHub.address, [WETH.address]);
     expect(wethBalance.platformBalance.gt(0)).to.be.true;
     expect(wethBalance.positions).to.have.lengthOf(2);
     const [position1, position2] = wethBalance.positions;
@@ -145,6 +146,7 @@ contract('DCAFeeManager', () => {
       DCAFeeManager.address
     );
     const { data: withdrawPositionsData } = await DCAFeeManager.populateTransaction.withdrawFromPositions(
+      DCAHub.address,
       [{ token: WETH.address, positionIds: [position1.positionId, position2.positionId] }],
       DCAFeeManager.address
     );
@@ -159,7 +161,7 @@ contract('DCAFeeManager', () => {
 
     // Make sure that everything was transferred to recipient
     const recipientBalance = await ethers.provider.getBalance(RECIPIENT);
-    const [wethBalanceAfter] = await DCAFeeManager.availableBalances([WETH.address]);
+    const [wethBalanceAfter] = await DCAFeeManager.availableBalances(DCAHub.address, [WETH.address]);
     expect(wethBalanceAfter.platformBalance).to.equal(0);
     const [position1After, position2After] = wethBalanceAfter.positions;
     expect(recipientBalance).to.equal(wethBalance.platformBalance.add(position1.swapped).add(position2.swapped));

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -45,7 +45,7 @@ contract('DCAFeeManager', () => {
     wToken = await wTokenFactory.deploy('WETH', 'WETH', 18);
     await setProtocolBalance(wToken, utils.parseEther('100'));
     DCAFeeManagerFactory = await ethers.getContractFactory('contracts/mocks/DCAFeeManager/DCAFeeManager.sol:DCAFeeManagerMock');
-    DCAFeeManager = await DCAFeeManagerFactory.deploy(DCAHub.address, wToken.address, governor.address);
+    DCAFeeManager = await DCAFeeManagerFactory.deploy(wToken.address, governor.address);
     snapshotId = await snapshot.take();
   });
 
@@ -64,9 +64,6 @@ contract('DCAFeeManager', () => {
 
   describe('constructor', () => {
     when('contract is initiated', () => {
-      then('hub is set correctly', async () => {
-        expect(await DCAFeeManager.hub()).to.equal(DCAHub.address);
-      });
       then('max token total share is set correctly', async () => {
         expect(await DCAFeeManager.MAX_TOKEN_TOTAL_SHARE()).to.equal(MAX_SHARES);
       });
@@ -141,7 +138,7 @@ contract('DCAFeeManager', () => {
     when('withdraw is executed', () => {
       const POSITION_SETS = [{ token: TOKEN_A, positionIds: [1, 2, 3] }];
       given(async () => {
-        await DCAFeeManager.connect(governor).withdrawFromPositions(POSITION_SETS, RECIPIENT);
+        await DCAFeeManager.connect(governor).withdrawFromPositions(DCAHub.address, POSITION_SETS, RECIPIENT);
       });
       then('hub is called correctly', () => {
         expect(DCAHub.withdrawSwappedMany).to.have.been.calledOnce;
@@ -152,7 +149,7 @@ contract('DCAFeeManager', () => {
     });
     shouldOnlyBeExecutableByGovernorOrAllowed({
       funcAndSignature: 'withdrawFromPositions',
-      params: [[], RECIPIENT],
+      params: () => [DCAHub.address, [], RECIPIENT],
     });
   });
 
@@ -192,6 +189,7 @@ contract('DCAFeeManager', () => {
       given(async () => {
         erc20Token.allowance.returns(0);
         await DCAFeeManager.connect(governor).fillPositions(
+          DCAHub.address,
           [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
           DISTRIBUTION
         );
@@ -204,6 +202,7 @@ contract('DCAFeeManager', () => {
       given(async () => {
         erc20Token.allowance.returns(1);
         await DCAFeeManager.connect(governor).fillPositions(
+          DCAHub.address,
           [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
           DISTRIBUTION
         );
@@ -221,6 +220,7 @@ contract('DCAFeeManager', () => {
           DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].revertsAtCall(0);
           DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].returnsAtCall(1, POSITION_ID_TOKEN_B);
           await DCAFeeManager.connect(governor).fillPositions(
+            DCAHub.address,
             [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
             DISTRIBUTION
           );
@@ -254,6 +254,7 @@ contract('DCAFeeManager', () => {
           DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].returnsAtCall(0, POSITION_ID_TOKEN_A);
           DCAHub['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'].returnsAtCall(1, POSITION_ID_TOKEN_B);
           await DCAFeeManager.connect(governor).fillPositions(
+            DCAHub.address,
             [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
             DISTRIBUTION
           );
@@ -311,6 +312,7 @@ contract('DCAFeeManager', () => {
         given(async () => {
           DCAHub.increasePosition.revertsAtCall(0);
           await DCAFeeManager.connect(governor).fillPositions(
+            DCAHub.address,
             [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
             DISTRIBUTION
           );
@@ -323,6 +325,7 @@ contract('DCAFeeManager', () => {
       describe('and increase works', () => {
         given(async () => {
           await DCAFeeManager.connect(governor).fillPositions(
+            DCAHub.address,
             [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }],
             DISTRIBUTION
           );
@@ -341,7 +344,7 @@ contract('DCAFeeManager', () => {
 
     shouldOnlyBeExecutableByGovernorOrAllowed({
       funcAndSignature: 'fillPositions',
-      params: () => [[{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }], DISTRIBUTION],
+      params: () => [DCAHub.address, [{ token: erc20Token.address, amount: FULL_AMOUNT, amountOfSwaps: AMOUNT_OF_SWAPS }], DISTRIBUTION],
     });
   });
 
@@ -362,7 +365,7 @@ contract('DCAFeeManager', () => {
         }));
         await DCAFeeManager.setPosition(erc20Token.address, TOKEN_A, 1);
         await DCAFeeManager.setPosition(erc20Token.address, TOKEN_B, 2);
-        await DCAFeeManager.connect(governor).terminatePositions(POSITION_IDS, RECIPIENT);
+        await DCAFeeManager.connect(governor).terminatePositions(DCAHub.address, POSITION_IDS, RECIPIENT);
       });
       then('position 1 is terminated and deleted from fee manager', async () => {
         expect(DCAHub.terminate).to.have.been.calledWith(1, RECIPIENT, RECIPIENT);
@@ -380,7 +383,7 @@ contract('DCAFeeManager', () => {
     });
     shouldOnlyBeExecutableByGovernorOrAllowed({
       funcAndSignature: 'terminatePositions',
-      params: [[], RECIPIENT],
+      params: () => [DCAHub.address, [], RECIPIENT],
     });
   });
 
@@ -443,7 +446,7 @@ contract('DCAFeeManager', () => {
         await DCAFeeManager.setPositionsWithToken(erc20Token.address, [1, 2]);
       });
       then('balances are returned correctly', async () => {
-        const balances = await DCAFeeManager.availableBalances([erc20Token.address]);
+        const balances = await DCAFeeManager.availableBalances(DCAHub.address, [erc20Token.address]);
         expect(balances).to.have.lengthOf(1);
         expect(balances[0].token).to.equal(erc20Token.address);
         expect(balances[0].platformBalance).to.equal(PLATFORM_BALANCE);


### PR DESCRIPTION
We are now deleting `resetAllowance` and handling everything internally. It didn't make much sense to have it in another function, since `fillPositions` would revert until `resetAllowance` was called