### PR TITLE
refactor: take hub address available balances

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -15,8 +15,6 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   /// @inheritdoc IDCAFeeManager
   uint32 public constant SWAP_INTERVAL = 1 days;
   /// @inheritdoc IDCAFeeManager
-  IDCAHub public immutable hub;
-  /// @inheritdoc IDCAFeeManager
   IWrappedProtocolToken public immutable wToken;
   /// @inheritdoc IDCAFeeManager
   mapping(address => bool) public hasAccess;
@@ -25,12 +23,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
 
   mapping(address => uint256[]) internal _positionsWithToken; // token address => all positions with address as to
 
-  constructor(
-    IDCAHub _hub,
-    IWrappedProtocolToken _wToken,
-    address _governor
-  ) Governable(_governor) {
-    hub = _hub;
+  constructor(IWrappedProtocolToken _wToken, address _governor) Governable(_governor) {
     wToken = _wToken;
   }
 

--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -125,14 +125,14 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   }
 
   /// @inheritdoc IDCAFeeManager
-  function availableBalances(address[] calldata _tokens) external view returns (AvailableBalance[] memory _balances) {
+  function availableBalances(IDCAHub _hub, address[] calldata _tokens) external view returns (AvailableBalance[] memory _balances) {
     _balances = new AvailableBalance[](_tokens.length);
     for (uint256 i; i < _tokens.length; i++) {
       address _token = _tokens[i];
       uint256[] memory _positionIds = _positionsWithToken[_token];
       PositionBalance[] memory _positions = new PositionBalance[](_positionIds.length);
       for (uint256 j; j < _positionIds.length; j++) {
-        IDCAHubPositionHandler.UserPosition memory _userPosition = hub.userPosition(_positionIds[j]);
+        IDCAHubPositionHandler.UserPosition memory _userPosition = _hub.userPosition(_positionIds[j]);
         _positions[j] = PositionBalance({
           positionId: _positionIds[j],
           from: _userPosition.from,
@@ -143,7 +143,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
       }
       _balances[i] = AvailableBalance({
         token: _token,
-        platformBalance: hub.platformBalance(_token),
+        platformBalance: _hub.platformBalance(_token),
         feeManagerBalance: IERC20(_token).balanceOf(address(this)),
         positions: _positions
       });

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -76,13 +76,6 @@ interface IDCAFeeManager is IGovernable {
   function SWAP_INTERVAL() external view returns (uint32);
 
   /**
-   * @notice Returns address for the DCA Hub
-   * @dev This value cannot be modified after deployment
-   * @return The address for the DCA Hub
-   */
-  function hub() external view returns (IDCAHub);
-
-  /**
    * @notice Returns address for the wToken
    * @dev This value cannot be modified after deployment
    * @return The address for the wToken

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -192,8 +192,9 @@ interface IDCAFeeManager is IGovernable {
   /**
    * @notice Returns how much is available for withdraw, for the given tokens
    * @dev This is meant for off-chan purposes
+   * @param hub The address of the DCA Hub
    * @param tokens The tokens to check the balance for
    * @return How much is available for withdraw, for the given tokens
    */
-  function availableBalances(address[] calldata tokens) external view returns (AvailableBalance[] memory);
+  function availableBalances(IDCAHub hub, address[] calldata tokens) external view returns (AvailableBalance[] memory);
 }

--- a/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
@@ -4,11 +4,7 @@ pragma solidity >=0.8.7 <0.9.0;
 import '../../DCAFeeManager/DCAFeeManager.sol';
 
 contract DCAFeeManagerMock is DCAFeeManager {
-  constructor(
-    IDCAHub _hub,
-    IWrappedProtocolToken _wToken,
-    address _governor
-  ) DCAFeeManager(_hub, _wToken, _governor) {}
+  constructor(IWrappedProtocolToken _wToken, address _governor) DCAFeeManager(_wToken, _governor) {}
 
   function setPosition(
     address _from,

--- a/deploy/005_fee_manager.ts
+++ b/deploy/005_fee_manager.ts
@@ -34,8 +34,6 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
       throw new Error(`Unsupported chain '${hre.network.name}`);
   }
 
-  const hub = await hre.deployments.get('DCAHub');
-
   await deployThroughDeterministicFactory({
     deployer,
     name: 'DCAFeeManager',
@@ -43,8 +41,8 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     contract: 'contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager',
     bytecode: DCAFeeManager__factory.bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address'],
-      values: [hub.address, wProtocolToken, governor],
+      types: ['address', 'address'],
+      values: [wProtocolToken, governor],
     },
     log: !process.env.TEST,
   });

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -94,7 +94,7 @@ contract('DCAFeeManager', () => {
     await swap({ from: WBTC, to: USDC });
 
     // Calculate and verify balances
-    const [usdcBalance, wbtcBalance] = await DCAFeeManager.availableBalances([USDC.address, WBTC.address]);
+    const [usdcBalance, wbtcBalance] = await DCAFeeManager.availableBalances(DCAHub.address, [USDC.address, WBTC.address]);
     expect(usdcBalance.platformBalance.gt(0)).to.be.true;
     expect(usdcBalance.feeManagerBalance).to.equal(0);
     expect(wbtcBalance.platformBalance).to.equal(0);
@@ -125,7 +125,7 @@ contract('DCAFeeManager', () => {
     await swap({ from: USDC, to: WETH }, { from: WBTC, to: WETH });
 
     // Check balances
-    const [wethBalance] = await DCAFeeManager.availableBalances([WETH.address]);
+    const [wethBalance] = await DCAFeeManager.availableBalances(DCAHub.address, [WETH.address]);
     expect(wethBalance.platformBalance.gt(0)).to.be.true;
     expect(wethBalance.positions).to.have.lengthOf(2);
     const [position1, position2] = wethBalance.positions;
@@ -161,7 +161,7 @@ contract('DCAFeeManager', () => {
 
     // Make sure that everything was transferred to recipient
     const recipientBalance = await ethers.provider.getBalance(RECIPIENT);
-    const [wethBalanceAfter] = await DCAFeeManager.availableBalances([WETH.address]);
+    const [wethBalanceAfter] = await DCAFeeManager.availableBalances(DCAHub.address, [WETH.address]);
     expect(wethBalanceAfter.platformBalance).to.equal(0);
     const [position1After, position2After] = wethBalanceAfter.positions;
     expect(recipientBalance).to.equal(wethBalance.platformBalance.add(position1.swapped).add(position2.swapped));

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -449,7 +449,7 @@ contract('DCAFeeManager', () => {
         await DCAFeeManager.setPositionsWithToken(erc20Token.address, [1, 2]);
       });
       then('balances are returned correctly', async () => {
-        const balances = await DCAFeeManager.availableBalances([erc20Token.address]);
+        const balances = await DCAFeeManager.availableBalances(DCAHub.address, [erc20Token.address]);
         expect(balances).to.have.lengthOf(1);
         expect(balances[0].token).to.equal(erc20Token.address);
         expect(balances[0].platformBalance).to.equal(PLATFORM_BALANCE);

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -45,7 +45,7 @@ contract('DCAFeeManager', () => {
     wToken = await wTokenFactory.deploy('WETH', 'WETH', 18);
     await setProtocolBalance(wToken, utils.parseEther('100'));
     DCAFeeManagerFactory = await ethers.getContractFactory('contracts/mocks/DCAFeeManager/DCAFeeManager.sol:DCAFeeManagerMock');
-    DCAFeeManager = await DCAFeeManagerFactory.deploy(DCAHub.address, wToken.address, governor.address);
+    DCAFeeManager = await DCAFeeManagerFactory.deploy(wToken.address, governor.address);
     snapshotId = await snapshot.take();
   });
 
@@ -64,9 +64,6 @@ contract('DCAFeeManager', () => {
 
   describe('constructor', () => {
     when('contract is initiated', () => {
-      then('hub is set correctly', async () => {
-        expect(await DCAFeeManager.hub()).to.equal(DCAHub.address);
-      });
       then('max token total share is set correctly', async () => {
         expect(await DCAFeeManager.MAX_TOKEN_TOTAL_SHARE()).to.equal(MAX_SHARES);
       });


### PR DESCRIPTION
We are now taking the Hub as a parameter when calling `availableBalances`