### PR TITLE
refactor: stop taking hub as contract parameter

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -15,8 +15,6 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
   /// @inheritdoc IDCAFeeManager
   uint32 public constant SWAP_INTERVAL = 1 days;
   /// @inheritdoc IDCAFeeManager
-  IDCAHub public immutable hub;
-  /// @inheritdoc IDCAFeeManager
   IWrappedProtocolToken public immutable wToken;
   /// @inheritdoc IDCAFeeManager
   mapping(address => bool) public hasAccess;
@@ -25,12 +23,7 @@ contract DCAFeeManager is Governable, Multicall, IDCAFeeManager {
 
   mapping(address => uint256[]) internal _positionsWithToken; // token address => all positions with address as to
 
-  constructor(
-    IDCAHub _hub,
-    IWrappedProtocolToken _wToken,
-    address _governor
-  ) Governable(_governor) {
-    hub = _hub;
+  constructor(IWrappedProtocolToken _wToken, address _governor) Governable(_governor) {
     wToken = _wToken;
   }
 

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -76,13 +76,6 @@ interface IDCAFeeManager is IGovernable {
   function SWAP_INTERVAL() external view returns (uint32);
 
   /**
-   * @notice Returns address for the DCA Hub
-   * @dev This value cannot be modified after deployment
-   * @return The address for the DCA Hub
-   */
-  function hub() external view returns (IDCAHub);
-
-  /**
    * @notice Returns address for the wToken
    * @dev This value cannot be modified after deployment
    * @return The address for the wToken

--- a/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
@@ -4,11 +4,7 @@ pragma solidity >=0.8.7 <0.9.0;
 import '../../DCAFeeManager/DCAFeeManager.sol';
 
 contract DCAFeeManagerMock is DCAFeeManager {
-  constructor(
-    IDCAHub _hub,
-    IWrappedProtocolToken _wToken,
-    address _governor
-  ) DCAFeeManager(_hub, _wToken, _governor) {}
+  constructor(IWrappedProtocolToken _wToken, address _governor) DCAFeeManager(_wToken, _governor) {}
 
   function setPosition(
     address _from,

--- a/deploy/005_fee_manager.ts
+++ b/deploy/005_fee_manager.ts
@@ -34,8 +34,6 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
       throw new Error(`Unsupported chain '${hre.network.name}`);
   }
 
-  const hub = await hre.deployments.get('DCAHub');
-
   await deployThroughDeterministicFactory({
     deployer,
     name: 'DCAFeeManager',
@@ -43,8 +41,8 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     contract: 'contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager',
     bytecode: DCAFeeManager__factory.bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address'],
-      values: [hub.address, wProtocolToken, governor],
+      types: ['address', 'address'],
+      values: [wProtocolToken, governor],
     },
     log: !process.env.TEST,
   });

--- a/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/unit/DCAFeeManager/dca-fee-manager.spec.ts
@@ -45,7 +45,7 @@ contract('DCAFeeManager', () => {
     wToken = await wTokenFactory.deploy('WETH', 'WETH', 18);
     await setProtocolBalance(wToken, utils.parseEther('100'));
     DCAFeeManagerFactory = await ethers.getContractFactory('contracts/mocks/DCAFeeManager/DCAFeeManager.sol:DCAFeeManagerMock');
-    DCAFeeManager = await DCAFeeManagerFactory.deploy(DCAHub.address, wToken.address, governor.address);
+    DCAFeeManager = await DCAFeeManagerFactory.deploy(wToken.address, governor.address);
     snapshotId = await snapshot.take();
   });
 
@@ -64,9 +64,6 @@ contract('DCAFeeManager', () => {
 
   describe('constructor', () => {
     when('contract is initiated', () => {
-      then('hub is set correctly', async () => {
-        expect(await DCAFeeManager.hub()).to.equal(DCAHub.address);
-      });
       then('max token total share is set correctly', async () => {
         expect(await DCAFeeManager.MAX_TOKEN_TOTAL_SHARE()).to.equal(MAX_SHARES);
       });


### PR DESCRIPTION
After all the recent PRs, we can now stop taking the hub as a contract parameter