### PR TITLE
refactor: change governable for access control

### DIFF
--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.7 <0.9.0;
 
 import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHub.sol';
 import './IWrappedProtocolToken.sol';
-import './utils/IGovernable.sol';
 
 /**
  * @title DCA Fee Manager
@@ -12,17 +11,11 @@ import './utils/IGovernable.sol';
  *         or stablecoins. Allowed users will to withdraw fees as generated, or DCA them into tokens
  *         of their choosing
  */
-interface IDCAFeeManager is IGovernable {
+interface IDCAFeeManager {
   /// @notice Represents a share of a target token
   struct TargetTokenShare {
     address token;
     uint16 shares;
-  }
-
-  /// @notice Represents a user and the new access that should be assigned to them
-  struct UserAccess {
-    address user;
-    bool access;
   }
 
   /// @notice Represents how much to deposit to a position, for a specific token
@@ -49,14 +42,8 @@ interface IDCAFeeManager is IGovernable {
     uint256 remaining;
   }
 
-  /// @notice Thrown when a user tries to execute a permissioned action without the access to do so
-  error CallerMustBeOwnerOrHaveAccess();
-
-  /**
-   * @notice Emitted when access is modified for some users
-   * @param access The modified users and their new access
-   */
-  event NewAccess(UserAccess[] access);
+  /// @notice Thrown when one of the parameters is a zero address
+  error ZeroAddress();
 
   /**
    * @notice The contract's owner and other allowed users can specify the target tokens that the fees
@@ -81,13 +68,6 @@ interface IDCAFeeManager is IGovernable {
    * @return The address for the wToken
    */
   function wToken() external view returns (IWrappedProtocolToken);
-
-  /**
-   * @notice Returns whether the given user has access to fill positions or execute withdraws
-   * @param user The user to check access for
-   * @return Whether the given user has access
-   */
-  function hasAccess(address user) external view returns (bool);
 
   /**
    * @notice Returns the position id for a given (from, to) pair
@@ -174,13 +154,6 @@ interface IDCAFeeManager is IGovernable {
     uint256[] calldata positionIds,
     address recipient
   ) external;
-
-  /**
-   * @notice Gives or takes access to permissioned actions from users
-   * @dev Only the contract owner can execute this action
-   * @param access The users to affect, and how to affect them
-   */
-  function setAccess(UserAccess[] calldata access) external;
 
   /**
    * @notice Returns how much is available for withdraw, for the given tokens

--- a/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
@@ -4,7 +4,11 @@ pragma solidity >=0.8.7 <0.9.0;
 import '../../DCAFeeManager/DCAFeeManager.sol';
 
 contract DCAFeeManagerMock is DCAFeeManager {
-  constructor(IWrappedProtocolToken _wToken, address _governor) DCAFeeManager(_wToken, _governor) {}
+  constructor(
+    IWrappedProtocolToken _wToken,
+    address _superAdmin,
+    address[] memory _initialAdmins
+  ) DCAFeeManager(_wToken, _superAdmin, _initialAdmins) {}
 
   function setPosition(
     address _from,

--- a/deploy/005_fee_manager.ts
+++ b/deploy/005_fee_manager.ts
@@ -41,8 +41,8 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     contract: 'contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager',
     bytecode: DCAFeeManager__factory.bytecode,
     constructorArgs: {
-      types: ['address', 'address'],
-      values: [wProtocolToken, governor],
+      types: ['address', 'address', 'address[]'],
+      values: [wProtocolToken, governor, [governor]],
     },
     log: !process.env.TEST,
   });

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -24,7 +24,7 @@ const WBTC_WHALE_ADDRESS = '0x9ff58f4ffb29fa2266ab25e75e2a8b3503311656';
 contract('DCAFeeManager', () => {
   const RECIPIENT = wallet.generateRandomAddress();
   let WETH: IERC20, USDC: IERC20, WBTC: IERC20;
-  let governor: JsonRpcSigner;
+  let superAdmin: JsonRpcSigner;
   let cindy: SignerWithAddress, allowed: SignerWithAddress, swapper: SignerWithAddress;
   let DCAFeeManager: DCAFeeManager;
   let DCAHubSwapper: DCAHubSwapper;
@@ -40,7 +40,7 @@ contract('DCAFeeManager', () => {
 
     const namedAccounts = await getNamedAccounts();
     const governorAddress = namedAccounts.governor;
-    governor = await wallet.impersonate(governorAddress);
+    superAdmin = await wallet.impersonate(governorAddress);
     await ethers.provider.send('hardhat_setBalance', [governorAddress, '0xffffffffffffffff']);
 
     const deterministicFactory = await ethers.getContractAt<DeterministicFactory>(
@@ -48,7 +48,7 @@ contract('DCAFeeManager', () => {
       '0xbb681d77506df5CA21D2214ab3923b4C056aa3e2'
     );
 
-    await deterministicFactory.connect(governor).grantRole(await deterministicFactory.DEPLOYER_ROLE(), namedAccounts.deployer);
+    await deterministicFactory.connect(superAdmin).grantRole(await deterministicFactory.DEPLOYER_ROLE(), namedAccounts.deployer);
 
     await deployments.run(['DCAHub', 'DCAHubSwapper', 'DCAFeeManager'], {
       resetMemory: true,
@@ -61,9 +61,9 @@ contract('DCAFeeManager', () => {
     DCAFeeManager = await ethers.getContract('DCAFeeManager');
 
     // Set up tokens and permissions
-    await DCAHub.connect(governor).setAllowedTokens([WETH_ADDRESS, USDC_ADDRESS, WBTC_ADDRESS], [true, true, true]);
-    await DCAHub.connect(governor).grantRole(await DCAHub.PLATFORM_WITHDRAW_ROLE(), DCAFeeManager.address);
-    await DCAFeeManager.connect(governor).setAccess([{ user: allowed.address, access: true }]);
+    await DCAHub.connect(superAdmin).setAllowedTokens([WETH_ADDRESS, USDC_ADDRESS, WBTC_ADDRESS], [true, true, true]);
+    await DCAHub.connect(superAdmin).grantRole(await DCAHub.PLATFORM_WITHDRAW_ROLE(), DCAFeeManager.address);
+    await DCAFeeManager.connect(superAdmin).grantRole(await DCAFeeManager.ADMIN_ROLE(), allowed.address);
 
     WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
     USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);


### PR DESCRIPTION
We are now simplifying the Fee Manager. We had a governor + allowed. This was basically AccessControl with two different roles. For consistency, we are moving towards AccessControl + Super Admin + Admins, like in our other repos

Look at all that deleted code
![image](https://user-images.githubusercontent.com/15222168/180607521-75077603-7a4a-43ca-be01-48a48d32c373.png)