### PR TITLE
refactor: avoid taking tokens from caller

### DIFF
--- a/contracts/DCAHubCompanion/DCAHubCompanionParameters.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionParameters.sol
@@ -12,8 +12,6 @@ abstract contract DCAHubCompanionParameters is IDCAHubCompanionParameters {
   IWrappedProtocolToken public immutable wToken;
   /// @inheritdoc IDCAHubCompanionParameters
   address public constant PROTOCOL_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-  /// @inheritdoc IDCAHubCompanionParameters
-  mapping(address => bool) public tokenHasApprovalIssue;
 
   constructor(
     IDCAHub _hub,
@@ -30,12 +28,6 @@ abstract contract DCAHubCompanionParameters is IDCAHubCompanionParameters {
 
   function _checkPermissionOrFail(uint256 _positionId, IDCAPermissionManager.Permission _permission) internal view {
     if (!permissionManager.hasPermission(_positionId, msg.sender, _permission)) revert IDCAHubCompanion.UnauthorizedCaller();
-  }
-
-  function _approveHub(address _from, uint256 _amount) internal {
-    // If the token we are going to approve doesn't have the approval issue we see in USDT, we will approve 1 extra.
-    // We are doing that so that the allowance isn't fully spent, and the next approve is cheaper.
-    IERC20(_from).approve(address(hub), tokenHasApprovalIssue[_from] ? _amount : _amount + 1);
   }
 
   modifier checkPermission(uint256 _positionId, IDCAPermissionManager.Permission _permission) {

--- a/contracts/interfaces/IDCAHubCompanion.sol
+++ b/contracts/interfaces/IDCAHubCompanion.sol
@@ -27,11 +27,6 @@ interface IDCAHubCompanionParameters {
   /// @notice Returns the permission manager contract
   /// @return The contract itself
   function permissionManager() external view returns (IDCAPermissionManager);
-
-  /// @notice Returns whether the given address has issues with approvals, like USDT
-  /// @param _tokenAddress The address of the token to check
-  /// @return Whether it has issues or not
-  function tokenHasApprovalIssue(address _tokenAddress) external view returns (bool);
 }
 
 interface IDCAHubCompanionSwapHandler is IDCAHubSwapCallee {
@@ -262,7 +257,6 @@ interface IDCAHubCompanionMulticallHandler {
   /// @param _swapInterval How frequently the position's swaps should be executed
   /// @param _owner The address of the owner of the position being created
   /// @param _miscellaneous Bytes that will be emitted, and associated with the position. If empty, no event will be emitted
-  /// @param _transferFromCaller Determines if the funds should be transfered from the caller
   /// @return _positionId The id of the created position
   function depositProxy(
     address _from,
@@ -272,8 +266,7 @@ interface IDCAHubCompanionMulticallHandler {
     uint32 _swapInterval,
     address _owner,
     IDCAPermissionManager.PermissionSet[] calldata _permissions,
-    bytes calldata _miscellaneous,
-    bool _transferFromCaller
+    bytes calldata _miscellaneous
   ) external payable returns (uint256 _positionId);
 
   /// @notice Call the hub and withdraws all swapped tokens from a position to a recipient
@@ -299,12 +292,10 @@ interface IDCAHubCompanionMulticallHandler {
   /// @param _positionId The position's id
   /// @param _amount Amount of funds to add to the position
   /// @param _newSwaps The new amount of swaps
-  /// @param _transferFromCaller Determines if the funds should be transfered from the caller
   function increasePositionProxy(
     uint256 _positionId,
     uint256 _amount,
-    uint32 _newSwaps,
-    bool _transferFromCaller
+    uint32 _newSwaps
   ) external payable;
 
   /// @notice Call the hub and withdraws the specified amount from the unswapped balance and modifies the position so that

--- a/test/integration/DCAHubCompanion/multi-call.spec.ts
+++ b/test/integration/DCAHubCompanion/multi-call.spec.ts
@@ -326,8 +326,7 @@ contract('Multicall', () => {
         SwapInterval.ONE_MINUTE.seconds,
         positionOwner.address,
         [],
-        ethers.utils.randomBytes(0),
-        false
+        ethers.utils.randomBytes(0)
       );
 
       await DCAHubCompanion.multicall([permissionData, withdrawData!, depositData!]);


### PR DESCRIPTION
We continue with small changes. Right now, we are no longer taking tokens from the caller when executing `depositProxy` or `increasePositionProxy`