### PR TITLE
feat: deposit with all balance

### DIFF
--- a/contracts/DCAHubCompanion/DCAHubCompanionHubProxyHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionHubProxyHandler.sol
@@ -32,11 +32,26 @@ abstract contract DCAHubCompanionHubProxyHandler is IDCAHubCompanionHubProxyHand
     address _owner,
     IDCAPermissionManager.PermissionSet[] calldata _permissions,
     bytes calldata _miscellaneous
-  ) external payable returns (uint256 _positionId) {
+  ) public payable virtual returns (uint256 _positionId) {
     _approveHub(address(_from), _hub, _amount);
     _positionId = _miscellaneous.length > 0
       ? _hub.deposit(_from, _to, _amount, _amountOfSwaps, _swapInterval, _owner, _permissions, _miscellaneous)
       : _hub.deposit(_from, _to, _amount, _amountOfSwaps, _swapInterval, _owner, _permissions);
+  }
+
+  /// @inheritdoc IDCAHubCompanionHubProxyHandler
+  function depositWithAllBalanceProxy(
+    IDCAHub _hub,
+    address _from,
+    address _to,
+    uint32 _amountOfSwaps,
+    uint32 _swapInterval,
+    address _owner,
+    IDCAPermissionManager.PermissionSet[] calldata _permissions,
+    bytes calldata _miscellaneous
+  ) external payable returns (uint256 _positionId) {
+    uint256 _amount = IERC20(_from).balanceOf(address(this));
+    return depositProxy(_hub, _from, _to, _amount, _amountOfSwaps, _swapInterval, _owner, _permissions, _miscellaneous);
   }
 
   /// @inheritdoc IDCAHubCompanionHubProxyHandler

--- a/contracts/interfaces/IDCAHubCompanion.sol
+++ b/contracts/interfaces/IDCAHubCompanion.sol
@@ -56,6 +56,29 @@ interface IDCAHubCompanionHubProxyHandler {
   ) external payable returns (uint256 positionId);
 
   /**
+   * @notice Creates a new position using the entire balance available on the contract
+   * @dev Meant to be used as part of a multicall
+   * @param hub The address of the DCAHub
+   * @param from The address of the "from" token
+   * @param to The address of the "to" token
+   * @param amountOfSwaps How many swaps to execute for this position
+   * @param swapInterval How frequently the position's swaps should be executed
+   * @param owner The address of the owner of the position being created
+   * @param miscellaneous Bytes that will be emitted, and associated with the position. If empty, no event will be emitted
+   * @return positionId The id of the created position
+   */
+  function depositWithAllBalanceProxy(
+    IDCAHub hub,
+    address from,
+    address to,
+    uint32 amountOfSwaps,
+    uint32 swapInterval,
+    address owner,
+    IDCAPermissionManager.PermissionSet[] calldata permissions,
+    bytes calldata miscellaneous
+  ) external payable returns (uint256 positionId);
+
+  /**
    * @notice Call the hub and withdraws all swapped tokens from a position to a recipient
    * @dev Meant to be used as part of a multicall
    * @param hub The address of the DCAHub

--- a/contracts/mocks/DCAHubCompanion/DCAHubCompanionHubProxyHandler.sol
+++ b/contracts/mocks/DCAHubCompanion/DCAHubCompanionHubProxyHandler.sol
@@ -3,4 +3,49 @@ pragma solidity >=0.8.7 <0.9.0;
 
 import '../../DCAHubCompanion/DCAHubCompanionHubProxyHandler.sol';
 
-contract DCAHubCompanionHubProxyHandlerMock is DCAHubCompanionHubProxyHandler {}
+contract DCAHubCompanionHubProxyHandlerMock is DCAHubCompanionHubProxyHandler {
+  struct DepositProxyCall {
+    IDCAHub hub;
+    address from;
+    address to;
+    uint256 amount;
+    uint32 amountOfSwaps;
+    uint32 swapInterval;
+    address owner;
+    IDCAPermissionManager.PermissionSet[] permissions;
+    bytes miscellaneous;
+  }
+
+  DepositProxyCall[] private _depositProxyCalls;
+
+  function depositProxyCalls() external view returns (DepositProxyCall[] memory) {
+    return _depositProxyCalls;
+  }
+
+  function depositProxy(
+    IDCAHub _hub,
+    address _from,
+    address _to,
+    uint256 _amount,
+    uint32 _amountOfSwaps,
+    uint32 _swapInterval,
+    address _owner,
+    IDCAPermissionManager.PermissionSet[] calldata _permissions,
+    bytes calldata _miscellaneous
+  ) public payable override returns (uint256 _positionId) {
+    _depositProxyCalls.push();
+    DepositProxyCall storage _ref = _depositProxyCalls[_depositProxyCalls.length - 1];
+    _ref.hub = _hub;
+    _ref.from = _from;
+    _ref.to = _to;
+    _ref.amount = _amount;
+    _ref.amountOfSwaps = _amountOfSwaps;
+    _ref.swapInterval = _swapInterval;
+    _ref.owner = _owner;
+    _ref.miscellaneous = _miscellaneous;
+    for (uint256 i = 0; i < _permissions.length; i++) {
+      _ref.permissions.push(_permissions[i]);
+    }
+    return super.depositProxy(_hub, _from, _to, _amount, _amountOfSwaps, _swapInterval, _owner, _permissions, _miscellaneous);
+  }
+}

--- a/test/unit/DCAHubCompanion/dca-hub-companion-hub-proxy-handler.spec.ts
+++ b/test/unit/DCAHubCompanion/dca-hub-companion-hub-proxy-handler.spec.ts
@@ -182,7 +182,7 @@ contract('DCAHubCompanionHubProxyHandler', () => {
     });
   });
 
-  describe.only('depositWithAllBalanceProxy', () => {
+  describe('depositWithAllBalanceProxy', () => {
     const TO = '0x0000000000000000000000000000000000000002';
     const AMOUNT = 10000;
     const AMOUNT_OF_SWAPS = 40;


### PR DESCRIPTION
One of the new use cases that we want to enable is:
1. Take token from user
2. Convert token to another token (maybe the yield-bearing version of the original token)
3. Deposit the converted token to the Hub

Since slippage can happen in the conversion, the idea is to have a function that takes the Companion's entire balance