### PR TITLE
feat: add new handle with dexes

### DIFF
--- a/contracts/DCAHubSwapper/DCAHubSwapper.sol
+++ b/contracts/DCAHubSwapper/DCAHubSwapper.sol
@@ -9,6 +9,7 @@ contract DCAHubSwapper is DCAHubSwapperParameters, DCAHubSwapperSwapHandler, DCA
   constructor(
     IDCAHub _hub,
     IWrappedProtocolToken _wToken,
-    address _governor
-  ) DCAHubSwapperParameters(_hub, _wToken, _governor) {}
+    address _governor,
+    address _swapperRegistry
+  ) DCAHubSwapperParameters(_hub, _wToken, _governor) DCAHubSwapperSwapHandler(_swapperRegistry) {}
 }

--- a/contracts/DCAHubSwapper/DCAHubSwapperParameters.sol
+++ b/contracts/DCAHubSwapper/DCAHubSwapperParameters.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import '@mean-finance/swappers/solidity/contracts/SwapAdapter.sol';
 import '../interfaces/IDCAHubSwapper.sol';
 import '../utils/Governable.sol';
 
@@ -17,7 +18,7 @@ abstract contract DCAHubSwapperParameters is Governable, IDCAHubSwapperParameter
     IWrappedProtocolToken _wToken,
     address _governor
   ) Governable(_governor) {
-    if (address(_hub) == address(0) || address(_wToken) == address(0)) revert IDCAHubSwapper.ZeroAddress();
+    if (address(_hub) == address(0) || address(_wToken) == address(0)) revert ISwapAdapter.ZeroAddress();
     hub = _hub;
     wToken = _wToken;
   }

--- a/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
+++ b/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
@@ -24,7 +24,7 @@ abstract contract DCAHubSwapperSwapHandler is DeadlineValidation, DCAHubSwapperP
     bytes data;
   }
   /// @notice Data used for the callback
-  struct SwapWithDexCallbackData {
+  struct SwapWithDexesCallbackData {
     // The different swappers involved in the swap
     address[] swappers;
     // The different swaps to execute
@@ -175,7 +175,7 @@ abstract contract DCAHubSwapperSwapHandler is DeadlineValidation, DCAHubSwapperP
   }
 
   function _handleSwapWithDexesCallback(IDCAHub.TokenInSwap[] calldata _tokens, bytes memory _data) internal {
-    SwapWithDexCallbackData memory _callbackData = abi.decode(_data, (SwapWithDexCallbackData));
+    SwapWithDexesCallbackData memory _callbackData = abi.decode(_data, (SwapWithDexesCallbackData));
 
     // Validate that all swappers are allowlisted
     for (uint256 i; i < _callbackData.swappers.length; i++) {

--- a/contracts/interfaces/IDCAHubSwapper.sol
+++ b/contracts/interfaces/IDCAHubSwapper.sol
@@ -40,6 +40,14 @@ interface IDCAHubSwapperParameters is IGovernable {
 }
 
 interface IDCAHubSwapperSwapHandler is IDCAHubSwapCallee {
+  /// @notice The data necessary for a swap to be executed
+  struct SwapExecution {
+    // The index of the swapper in the swapper array
+    uint8 swapperIndex;
+    // The swap's execution
+    bytes swapData;
+  }
+
   /// @notice Thrown when the reward is less that the specified minimum
   error RewardNotEnough();
 
@@ -138,10 +146,4 @@ interface IDCAHubSwapperSwapHandler is IDCAHubSwapCallee {
 
 interface IDCAHubSwapperDustHandler is ICollectableDust {}
 
-interface IDCAHubSwapper is IDCAHubSwapperParameters, IDCAHubSwapperSwapHandler, IDCAHubSwapperDustHandler {
-  /// @notice Thrown when one of the parameters is a zero address
-  error ZeroAddress();
-
-  /// @notice Thrown when a user tries operate on a position that they don't have access to
-  error UnauthorizedCaller();
-}
+interface IDCAHubSwapper is IDCAHubSwapperParameters, IDCAHubSwapperSwapHandler, IDCAHubSwapperDustHandler {}

--- a/contracts/mocks/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
+++ b/contracts/mocks/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
@@ -10,8 +10,9 @@ contract DCAHubSwapperSwapHandlerMock is DCAHubSwapperSwapHandler, DCAHubSwapper
   constructor(
     IDCAHub _hub,
     IWrappedProtocolToken _wToken,
-    address _governor
-  ) DCAHubSwapperParametersMock(_hub, _wToken, _governor) {}
+    address _governor,
+    address _swapperRegistry
+  ) DCAHubSwapperParametersMock(_hub, _wToken, _governor) DCAHubSwapperSwapHandler(_swapperRegistry) {}
 
   function _callDex(address _dex, bytes memory _data) internal override {
     _dexCalledWith[_dex].push(_data);

--- a/contracts/mocks/ISwapper.sol
+++ b/contracts/mocks/ISwapper.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.8.7 <0.9.0;
+
+/// @notice Simply used for tests with Smock
+interface ISwapper {
+  function swap(
+    address tokenIn,
+    uint256 amountIn,
+    address tokenOut
+  ) external;
+}

--- a/deploy/002_swapper.ts
+++ b/deploy/002_swapper.ts
@@ -38,12 +38,13 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
   await deployThroughDeterministicFactory({
     deployer,
     name: 'DCAHubSwapper',
-    salt: 'MF-DCAV2-DCAHubSwapper-V2',
+    salt: 'MF-DCAV2-DCAHubSwapper-V3',
     contract: 'contracts/DCAHubSwapper/DCAHubSwapper.sol:DCAHubSwapper',
     bytecode: DCAHubSwapper__factory.bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address'],
-      values: [hub.address, wProtocolToken, governor],
+      types: ['address', 'address', 'address', 'address'],
+      // TODO: Update to use the real swapper registry in the future
+      values: [hub.address, wProtocolToken, governor, '0x0000000000000000000000000000000000000001'],
     },
     log: !process.env.TEST,
   });

--- a/test/integration/V2Migration/position-migrator.spec.ts
+++ b/test/integration/V2Migration/position-migrator.spec.ts
@@ -171,7 +171,7 @@ contract('PositionMigrator', () => {
     const DCAHubSwapperFactory: DCAHubSwapper__factory = await ethers.getContractFactory(
       'contracts/DCAHubSwapper/DCAHubSwapper.sol:DCAHubSwapper'
     );
-    const DCAHubSwapper = await DCAHubSwapperFactory.deploy(hub.address, WETH.address, constants.NOT_ZERO_ADDRESS);
+    const DCAHubSwapper = await DCAHubSwapperFactory.deploy(hub.address, WETH.address, constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS);
     await WETH.connect(swapper).approve(DCAHubSwapper.address, constants.MAX_UINT_256);
     await DCAHubSwapper.connect(swapper).swapForCaller(
       hub.address,


### PR DESCRIPTION
We are now adding a new kind of swap to our DCASwapper (it's not yet callable, we are now simply handling the Hub's callback).

There are three main changes between this swap with dex and the previous one:
1. Our current swapWithDex allows the DCASwapper to take one dex, and multiple swaps (with that dex). Now, we are taking multiple swappers and multiple executions. This will allow us to choose better paths for our swaps, and handle more complex situations (like `USDC => yUSDC => WETH => yWETH`)
2. The current `swapWithDex` would handle approvals per swap. This meant that we would approve only what was needed, and we also needed to tackle special tokens, like USDT. Now, we are giving max approvals, which is **far** cheaper
3. Previously, we had a flag that would specify if the swap was a "swap and transfer". In that case, we would do things a little differently. It didn't help save any gas 😅 . If the tokens were sent to the Hub, we would still check the current balance and transfer it to another address. So we just removed that extra complexity