### PR TITLE
feat: add swap with dexes

### DIFF
--- a/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
+++ b/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
@@ -92,7 +92,7 @@ abstract contract DCAHubSwapperSwapHandler is DeadlineValidation, DCAHubSwapperP
   }
 
   /// @inheritdoc IDCAHubSwapperSwapHandler
-  function swapWithDexesByMeanKeepers(SwapWithDexesParams calldata _parameters) external payable returns (IDCAHub.SwapInfo memory) {
+  function swapWithDexesForMean(SwapWithDexesParams calldata _parameters) external payable returns (IDCAHub.SwapInfo memory) {
     return _swapWithDexes(_parameters, true);
   }
 

--- a/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
+++ b/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.7 <0.9.0;
 
 import '@mean-finance/swappers/solidity/contracts/SwapAdapter.sol';
-import '@mean-finance/swappers/solidity/contracts/extensions/Shared.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import './utils/DeadlineValidation.sol';
@@ -85,6 +84,47 @@ abstract contract DCAHubSwapperSwapHandler is DeadlineValidation, DCAHubSwapperP
 
     // Clear the swap executor
     _swapExecutor = _NO_EXECUTOR;
+  }
+
+  /// @inheritdoc IDCAHubSwapperSwapHandler
+  function swapWithDexes(SwapWithDexesParams calldata _parameters) external payable returns (IDCAHub.SwapInfo memory) {
+    return _swapWithDexes(_parameters, false);
+  }
+
+  /// @inheritdoc IDCAHubSwapperSwapHandler
+  function swapWithDexesByMeanKeepers(SwapWithDexesParams calldata _parameters) external payable returns (IDCAHub.SwapInfo memory) {
+    return _swapWithDexes(_parameters, true);
+  }
+
+  function _swapWithDexes(SwapWithDexesParams calldata _parameters, bool _sendToProvideLeftoverToHub)
+    internal
+    checkDeadline(_parameters.deadline)
+    returns (IDCAHub.SwapInfo memory)
+  {
+    // Approve whatever is necessary
+    for (uint256 i; i < _parameters.allowanceTargets.length; i++) {
+      Allowance memory _allowance = _parameters.allowanceTargets[i];
+      _maxApproveSpenderIfNeeded(_allowance.token, _allowance.allowanceTarget, false, _allowance.minAllowance);
+    }
+
+    // Prepare data for callback
+    SwapWithDexCallbackData memory _callbackData = SwapWithDexCallbackData({
+      swappers: _parameters.swappers,
+      executions: _parameters.executions,
+      leftoverRecipient: _parameters.leftoverRecipient,
+      sendToProvideLeftoverToHub: _sendToProvideLeftoverToHub
+    });
+
+    // Execute swap
+    return
+      _parameters.hub.swap(
+        _parameters.tokens,
+        _parameters.pairsToSwap,
+        address(this),
+        address(this),
+        new uint256[](_parameters.tokens.length),
+        abi.encode(SwapData({plan: SwapPlan.SWAP_WITH_DEXES, data: abi.encode(_callbackData)}))
+      );
   }
 
   /// @inheritdoc IDCAHubSwapperSwapHandler

--- a/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
+++ b/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
@@ -108,7 +108,7 @@ abstract contract DCAHubSwapperSwapHandler is DeadlineValidation, DCAHubSwapperP
     }
 
     // Prepare data for callback
-    SwapWithDexCallbackData memory _callbackData = SwapWithDexCallbackData({
+    SwapWithDexesCallbackData memory _callbackData = SwapWithDexesCallbackData({
       swappers: _parameters.swappers,
       executions: _parameters.executions,
       leftoverRecipient: _parameters.leftoverRecipient,

--- a/contracts/interfaces/IDCAHubSwapper.sol
+++ b/contracts/interfaces/IDCAHubSwapper.sol
@@ -131,7 +131,7 @@ interface IDCAHubSwapperSwapHandler is IDCAHubSwapCallee {
    *         sent to the provided recipient
    * @return The information about the executed swap
    */
-  function swapWithDexesByMeanKeepers(SwapWithDexesParams calldata parameters) external payable returns (IDCAHub.SwapInfo memory);
+  function swapWithDexesForMean(SwapWithDexesParams calldata parameters) external payable returns (IDCAHub.SwapInfo memory);
 
   /// @notice Executes a swap with the given DEX, and sends all unspent tokens to the given recipient
   /// @param _dex The DEX that will be used in the swap

--- a/contracts/mocks/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
+++ b/contracts/mocks/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
@@ -7,6 +7,15 @@ import './DCAHubSwapperParameters.sol';
 contract DCAHubSwapperSwapHandlerMock is DCAHubSwapperSwapHandler, DCAHubSwapperParametersMock {
   mapping(address => bytes[]) private _dexCalledWith;
 
+  struct MaxApproveSpenderCall {
+    IERC20 token;
+    address spender;
+    bool alreadyValidatedSpender;
+    uint256 minAllowance;
+  }
+
+  MaxApproveSpenderCall[] internal _maxApproveSpenderCalls;
+
   constructor(
     IDCAHub _hub,
     IWrappedProtocolToken _wToken,
@@ -20,6 +29,20 @@ contract DCAHubSwapperSwapHandlerMock is DCAHubSwapperSwapHandler, DCAHubSwapper
 
   function callsToDex(address _dex) external view returns (bytes[] memory) {
     return _dexCalledWith[_dex];
+  }
+
+  function maxApproveSpenderCalls() external view returns (MaxApproveSpenderCall[] memory) {
+    return _maxApproveSpenderCalls;
+  }
+
+  function _maxApproveSpenderIfNeeded(
+    IERC20 _token,
+    address _spender,
+    bool _alreadyValidatedSpender,
+    uint256 _minAllowance
+  ) internal override {
+    _maxApproveSpenderCalls.push(MaxApproveSpenderCall(_token, _spender, _alreadyValidatedSpender, _minAllowance));
+    super._maxApproveSpenderIfNeeded(_token, _spender, _alreadyValidatedSpender, _minAllowance);
   }
 
   function isSwapExecutorEmpty() external view returns (bool) {

--- a/test/unit/DCAHubSwapper/dca-hub-swapper-swap-handler.spec.ts
+++ b/test/unit/DCAHubSwapper/dca-hub-swapper-swap-handler.spec.ts
@@ -67,6 +67,7 @@ contract('DCAHubSwapperSwapHandler', () => {
     DCAHub.swap.reset();
     swapperRegistry.isSwapperAllowlisted.reset();
     swapperRegistry.isSwapperAllowlisted.returns(true);
+    swapperRegistry.isValidAllowanceTarget.returns(true);
   });
   describe('constructor', () => {
     when('contract is initiated', () => {
@@ -199,6 +200,112 @@ contract('DCAHubSwapperSwapHandler', () => {
       });
       then('swap executor is cleared', async () => {
         expect(await DCAHubSwapperSwapHandler.isSwapExecutorEmpty()).to.be.true;
+      });
+    });
+  });
+  describe('swapWithDexes', () => {
+    const BYTES = ethers.utils.randomBytes(10);
+    whenDeadlineHasExpiredThenTxReverts({
+      func: 'swapWithDexes',
+      args: () => [
+        {
+          hub: DCAHub.address,
+          tokens: [],
+          pairsToSwap: [],
+          allowanceTargets: [],
+          swappers: [],
+          executions: [],
+          leftoverRecipient: recipient.address,
+          deadline: 0,
+        },
+      ],
+    });
+    when('executing a swap with dexes', () => {
+      given(async () => {
+        await DCAHubSwapperSwapHandler.connect(swapper).swapWithDexes({
+          hub: DCAHub.address,
+          tokens: tokens,
+          pairsToSwap: INDEXES,
+          allowanceTargets: [{ token: tokenA.address, allowanceTarget: DEX, minAllowance: 2000 }],
+          swappers: [DEX],
+          executions: [{ swapData: BYTES, swapperIndex: 0 }],
+          leftoverRecipient: recipient.address,
+          deadline: constants.MAX_UINT_256,
+        });
+      });
+      then('allowance was called correctly', async () => {
+        const calls = await DCAHubSwapperSwapHandler.maxApproveSpenderCalls();
+        expect(calls).to.have.lengthOf(1);
+        expect(calls[0].token).to.equal(tokenA.address);
+        expect(calls[0].spender).to.equal(DEX);
+        expect(calls[0].minAllowance).to.equal(2000);
+        expect(calls[0].alreadyValidatedSpender).to.be.false;
+      });
+      thenHubIsCalledWith({
+        rewardRecipient: () => DCAHubSwapperSwapHandler,
+        data: () =>
+          encode({
+            plan: 'dexes',
+            bytes: {
+              swappers: [DEX],
+              executions: [{ data: BYTES, index: 0 }],
+              sendToProvideLeftoverToHub: false,
+              leftoverRecipient: recipient,
+            },
+          }),
+      });
+    });
+  });
+  describe('swapWithDexesByMeanKeepers', () => {
+    const BYTES = ethers.utils.randomBytes(10);
+    whenDeadlineHasExpiredThenTxReverts({
+      func: 'swapWithDexesByMeanKeepers',
+      args: () => [
+        {
+          hub: DCAHub.address,
+          tokens: [],
+          pairsToSwap: [],
+          allowanceTargets: [],
+          swappers: [],
+          executions: [],
+          leftoverRecipient: recipient.address,
+          deadline: 0,
+        },
+      ],
+    });
+    when('executing a swap with dexes', () => {
+      given(async () => {
+        await DCAHubSwapperSwapHandler.connect(swapper).swapWithDexesByMeanKeepers({
+          hub: DCAHub.address,
+          tokens: tokens,
+          pairsToSwap: INDEXES,
+          allowanceTargets: [{ token: tokenA.address, allowanceTarget: DEX, minAllowance: 2000 }],
+          swappers: [DEX],
+          executions: [{ swapData: BYTES, swapperIndex: 0 }],
+          leftoverRecipient: recipient.address,
+          deadline: constants.MAX_UINT_256,
+        });
+      });
+      then('allowance was called correctly', async () => {
+        const calls = await DCAHubSwapperSwapHandler.maxApproveSpenderCalls();
+        expect(calls).to.have.lengthOf(1);
+        expect(calls[0].token).to.equal(tokenA.address);
+        expect(calls[0].spender).to.equal(DEX);
+        expect(calls[0].minAllowance).to.equal(2000);
+        expect(calls[0].alreadyValidatedSpender).to.be.false;
+      });
+      thenHubIsCalledWith({
+        rewardRecipient: () => DCAHubSwapperSwapHandler,
+        data: () =>
+          encode({
+            plan: 'dexes',
+            bytes: {
+              swappers: [DEX],
+              executions: [{ data: BYTES, index: 0 }],
+              sendToProvideLeftoverToHub: true,
+              leftoverRecipient: recipient,
+            },
+          }),
       });
     });
   });
@@ -795,8 +902,8 @@ contract('DCAHubSwapperSwapHandler', () => {
   }) {
     then('hub was called with the correct parameters', () => {
       expect(DCAHub.swap).to.have.been.calledOnce;
-      const [tokens, indexes, rewardRecipient, callbackHandler, borrow, data] = DCAHub.swap.getCall(0).args;
-      expect(tokens).to.eql(tokens);
+      const [tokensInHub, indexes, rewardRecipient, callbackHandler, borrow, data] = DCAHub.swap.getCall(0).args;
+      expect(tokensInHub).to.eql(tokens);
       expect((indexes as any)[0]).to.eql([0, 1]);
       expect(rewardRecipient).to.equal(
         typeof expectedRewardRecipient === 'string' ? expectedRewardRecipient : expectedRewardRecipient().address

--- a/test/unit/DCAHubSwapper/dca-hub-swapper-swap-handler.spec.ts
+++ b/test/unit/DCAHubSwapper/dca-hub-swapper-swap-handler.spec.ts
@@ -256,10 +256,10 @@ contract('DCAHubSwapperSwapHandler', () => {
       });
     });
   });
-  describe('swapWithDexesByMeanKeepers', () => {
+  describe('swapWithDexesForMean', () => {
     const BYTES = ethers.utils.randomBytes(10);
     whenDeadlineHasExpiredThenTxReverts({
-      func: 'swapWithDexesByMeanKeepers',
+      func: 'swapWithDexesForMean',
       args: () => [
         {
           hub: DCAHub.address,
@@ -275,7 +275,7 @@ contract('DCAHubSwapperSwapHandler', () => {
     });
     when('executing a swap with dexes', () => {
       given(async () => {
-        await DCAHubSwapperSwapHandler.connect(swapper).swapWithDexesByMeanKeepers({
+        await DCAHubSwapperSwapHandler.connect(swapper).swapWithDexesForMean({
           hub: DCAHub.address,
           tokens: tokens,
           pairsToSwap: INDEXES,


### PR DESCRIPTION
We are now adding `swapWithDexes` and `swapWithDexesByMeanKeepers` (open to change the name on the second one, but I'm not sure what to name it)

These functions basically initiate the DCA swap that will handled by the new code in #109

**Note**: the integration tests fail with `InvalidInputError: Transaction gas limit is 30006104 and exceeds block gas limit of 30000000` because the swapper cannot be deployed. This is fixed in the next PR, when we delete a lot of the contract's code