### PR TITLE
feat: add swap extensions to companion

### DIFF
--- a/contracts/DCAHubCompanion/DCAHubCompanion.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanion.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import '@mean-finance/swappers/solidity/contracts/extensions/GetBalances.sol';
+import '@mean-finance/swappers/solidity/contracts/extensions/RevokableWithGovernor.sol';
 import './DCAHubCompanionLibrariesHandler.sol';
 import './DCAHubCompanionHubProxyHandler.sol';
 import './DCAHubCompanionTakeSendAndSwapHandler.sol';
@@ -10,8 +12,10 @@ contract DCAHubCompanion is
   DCAHubCompanionLibrariesHandler,
   DCAHubCompanionHubProxyHandler,
   DCAHubCompanionTakeSendAndSwapHandler,
+  RevokableWithGovernor,
+  GetBalances,
   Multicall,
   IDCAHubCompanion
 {
-  constructor(address _swapperRegistry) SwapAdapter(_swapperRegistry) {}
+  constructor(address _swapperRegistry, address _governor) SwapAdapter(_swapperRegistry) Governable(_governor) {}
 }

--- a/contracts/DCAHubCompanion/DCAHubCompanionTakeSendAndSwapHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionTakeSendAndSwapHandler.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
-import '@mean-finance/swappers/solidity/contracts/SwapAdapter.sol';
+import '@mean-finance/swappers/solidity/contracts/extensions/RunSwap.sol';
 import '../interfaces/IDCAHubCompanion.sol';
 
 /// @dev All public functions are payable, so that they can be multicalled together with other payable functions when msg.value > 0
-abstract contract DCAHubCompanionTakeSendAndSwapHandler is SwapAdapter, IDCAHubCompanionTakeSendAndSwapHandler {
+abstract contract DCAHubCompanionTakeSendAndSwapHandler is RunSwap, IDCAHubCompanionTakeSendAndSwapHandler {
   using SafeERC20 for IERC20;
   using Address for address payable;
 

--- a/contracts/DCAHubCompanion/DCAHubCompanionTakeSendAndSwapHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionTakeSendAndSwapHandler.sol
@@ -6,20 +6,13 @@ import '../interfaces/IDCAHubCompanion.sol';
 
 /// @dev All public functions are payable, so that they can be multicalled together with other payable functions when msg.value > 0
 abstract contract DCAHubCompanionTakeSendAndSwapHandler is RunSwap, IDCAHubCompanionTakeSendAndSwapHandler {
-  using SafeERC20 for IERC20;
-  using Address for address payable;
-
   /// @inheritdoc IDCAHubCompanionTakeSendAndSwapHandler
   function sendToRecipient(
     address _token,
     uint256 _amount,
     address _recipient
   ) external payable {
-    if (_token == PROTOCOL_TOKEN) {
-      payable(_recipient).sendValue(_amount);
-    } else {
-      IERC20(_token).safeTransfer(_recipient, _amount);
-    }
+    _sendToRecipient(_token, _amount, _recipient);
   }
 
   /// @inheritdoc IDCAHubCompanionTakeSendAndSwapHandler
@@ -29,6 +22,6 @@ abstract contract DCAHubCompanionTakeSendAndSwapHandler is RunSwap, IDCAHubCompa
 
   /// @inheritdoc IDCAHubCompanionTakeSendAndSwapHandler
   function sendBalanceOnContractToRecipient(address _token, address _recipient) external payable {
-    _sendBalanceToRecipient(_token, _recipient);
+    _sendBalanceOnContractToRecipient(_token, _recipient);
   }
 }

--- a/contracts/mocks/DCAHubCompanion/DCAHubCompanionTakeSendAndSwapHandler.sol
+++ b/contracts/mocks/DCAHubCompanion/DCAHubCompanionTakeSendAndSwapHandler.sol
@@ -11,20 +11,31 @@ contract DCAHubCompanionTakeSendAndSwapHandlerMock is DCAHubCompanionTakeSendAnd
     uint256 amount;
   }
 
-  struct SendBalanceToRecipientCall {
+  struct SendBalanceOnContractToRecipientCall {
     address token;
     address recipient;
   }
 
+  struct SendToRecipientCall {
+    address token;
+    uint256 amount;
+    address recipient;
+  }
+
   TakeFromMsgSenderCall[] internal _takeFromMsgSenderCalls;
-  SendBalanceToRecipientCall[] internal _sendBalanceToRecipientCalls;
+  SendBalanceOnContractToRecipientCall[] internal _sendBalanceOnContractToRecipientCalls;
+  SendToRecipientCall[] internal _sendToRecipientCalls;
 
   function takeFromMsgSenderCalls() external view returns (TakeFromMsgSenderCall[] memory) {
     return _takeFromMsgSenderCalls;
   }
 
-  function sendBalanceToRecipientCalls() external view returns (SendBalanceToRecipientCall[] memory) {
-    return _sendBalanceToRecipientCalls;
+  function sendBalanceOnContractToRecipientCalls() external view returns (SendBalanceOnContractToRecipientCall[] memory) {
+    return _sendBalanceOnContractToRecipientCalls;
+  }
+
+  function sendToRecipientCalls() external view returns (SendToRecipientCall[] memory) {
+    return _sendToRecipientCalls;
   }
 
   function _takeFromMsgSender(IERC20 _token, uint256 _amount) internal override {
@@ -32,8 +43,17 @@ contract DCAHubCompanionTakeSendAndSwapHandlerMock is DCAHubCompanionTakeSendAnd
     super._takeFromMsgSender(_token, _amount);
   }
 
-  function _sendBalanceToRecipient(address _token, address _recipient) internal override {
-    _sendBalanceToRecipientCalls.push(SendBalanceToRecipientCall(_token, _recipient));
-    super._sendBalanceToRecipient(_token, _recipient);
+  function _sendBalanceOnContractToRecipient(address _token, address _recipient) internal override {
+    _sendBalanceOnContractToRecipientCalls.push(SendBalanceOnContractToRecipientCall(_token, _recipient));
+    super._sendBalanceOnContractToRecipient(_token, _recipient);
+  }
+
+  function _sendToRecipient(
+    address _token,
+    uint256 _amount,
+    address _recipient
+  ) internal override {
+    _sendToRecipientCalls.push(SendToRecipientCall(_token, _amount, _recipient));
+    super._sendToRecipient(_token, _amount, _recipient);
   }
 }

--- a/deploy/001_companion.ts
+++ b/deploy/001_companion.ts
@@ -1,50 +1,22 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from '@0xged/hardhat-deploy/types';
-import { networkBeingForked } from '@test-utils/evm';
-import { DCAHubCompanion__factory } from '../typechained';
+import { bytecode } from '../artifacts/contracts/DCAHubCompanion/DCAHubCompanion.sol/DCAHubCompanion.json';
 import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-factory/utils/deployment';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, governor } = await hre.getNamedAccounts();
 
-  let wProtocolToken: string;
-  const network = hre.network.name !== 'hardhat' ? hre.network.name : networkBeingForked ?? hre.network.name;
-  switch (network) {
-    case 'hardhat':
-    case 'mainnet':
-      wProtocolToken = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // WETH
-      break;
-    case 'kovan':
-      wProtocolToken = '0xd0a1e359811322d97991e03f863a0c30c2cf029c'; // WETH
-      break;
-    case 'optimism-kovan':
-    case 'optimism':
-      wProtocolToken = '0x4200000000000000000000000000000000000006'; // WETH
-      break;
-    case 'arbitrum':
-      wProtocolToken = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'; // WETH
-      break;
-    case 'mumbai':
-      wProtocolToken = '0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889'; // WMATIC
-      break;
-    case 'polygon':
-      wProtocolToken = '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270'; // WMATIC
-      break;
-    default:
-      throw new Error(`Unsupported chain '${hre.network.name}`);
-  }
-
-  const hub = await hre.deployments.get('DCAHub');
+  const swapperRegistry = await hre.deployments.get('SwapperRegistry');
 
   await deployThroughDeterministicFactory({
     deployer,
     name: 'DCAHubCompanion',
-    salt: 'MF-DCAV2-DCAHubCompanion-V2',
+    salt: 'MF-DCAV2-DCAHubCompanion-V3',
     contract: 'contracts/DCAHubCompanion/DCAHubCompanion.sol:DCAHubCompanion',
-    bytecode: DCAHubCompanion__factory.bytecode,
+    bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address'],
-      values: [hub.address, wProtocolToken, governor],
+      types: ['address', 'address'],
+      values: [swapperRegistry.address, governor],
     },
     log: !process.env.TEST,
     overrides: {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@mean-finance/dca-v2-core": "2.1.0",
     "@mean-finance/deterministic-factory": "1.3.1",
-    "@mean-finance/swappers": "1.0.0-rc3"
+    "@mean-finance/swappers": "1.0.0-rc5"
   },
   "devDependencies": {
     "@0xged/hardhat-deploy": "0.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,10 +835,10 @@
     "@openzeppelin/contracts" "4.6.0"
     "@rari-capital/solmate" "6.2.0"
 
-"@mean-finance/swappers@1.0.0-rc3":
-  version "1.0.0-rc3"
-  resolved "https://registry.yarnpkg.com/@mean-finance/swappers/-/swappers-1.0.0-rc3.tgz#76cf84b8842cda6973d8d4d620b35422f1c88cbc"
-  integrity sha512-rEupuBFrvd5z174LOwZepgkqeNK9zGqJ0AfzyyvSyI2uC5JRKMlYnOXIT0WBtl4kJ4dMyer2BOoaa1XmDezm8A==
+"@mean-finance/swappers@1.0.0-rc5":
+  version "1.0.0-rc5"
+  resolved "https://registry.yarnpkg.com/@mean-finance/swappers/-/swappers-1.0.0-rc5.tgz#a4cd8cb4c8c8be64c14cecfdd9d6d502e633430d"
+  integrity sha512-mze6nRTq+cciQmO8bSNJOVVk6CLgSRobh2IRhrRzqQGeKLPHFV7MwczaNOd49ZF1DcsL1zqNK3w/W2tXr+eM9Q==
   dependencies:
     "@mean-finance/deterministic-factory" "1.3.1"
     "@openzeppelin/contracts" "4.6.0"


### PR DESCRIPTION
We doing a few things in this PR:
1. We are using the internal function for `sendToRecipient`
2. We are adding the following extensions to the companion:
    - `RunSwap`: so we can execute swaps
    - `RevokableWithGovernor`: to revoke potential access
    - `GetBalances `: to be able to easily read the contract's balance
3. Also, we fixed the Companion's deployment that was working on the tests for some reason 😆 