### PR TITLE
feat: make dca swapper permissioned

### DIFF
--- a/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
+++ b/contracts/DCAHubSwapper/DCAHubSwapperSwapHandler.sol
@@ -66,7 +66,7 @@ abstract contract DCAHubSwapperSwapHandler is DeadlineValidation, AccessControl,
     uint256[] calldata _maximumInput,
     address _recipient,
     uint256 _deadline
-  ) external payable checkDeadline(_deadline) returns (IDCAHub.SwapInfo memory _swapInfo) {
+  ) external payable checkDeadline(_deadline) onlyRole(SWAP_EXECUTION_ROLE) returns (IDCAHub.SwapInfo memory _swapInfo) {
     // Set the swap's executor
     _swapExecutor = msg.sender;
 
@@ -96,12 +96,22 @@ abstract contract DCAHubSwapperSwapHandler is DeadlineValidation, AccessControl,
   }
 
   /// @inheritdoc IDCAHubSwapperSwapHandler
-  function swapWithDexes(SwapWithDexesParams calldata _parameters) external payable returns (IDCAHub.SwapInfo memory) {
+  function swapWithDexes(SwapWithDexesParams calldata _parameters)
+    external
+    payable
+    onlyRole(SWAP_EXECUTION_ROLE)
+    returns (IDCAHub.SwapInfo memory)
+  {
     return _swapWithDexes(_parameters, false);
   }
 
   /// @inheritdoc IDCAHubSwapperSwapHandler
-  function swapWithDexesForMean(SwapWithDexesParams calldata _parameters) external payable returns (IDCAHub.SwapInfo memory) {
+  function swapWithDexesForMean(SwapWithDexesParams calldata _parameters)
+    external
+    payable
+    onlyRole(SWAP_EXECUTION_ROLE)
+    returns (IDCAHub.SwapInfo memory)
+  {
     return _swapWithDexes(_parameters, true);
   }
 

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -74,6 +74,7 @@ contract('DCAFeeManager', () => {
     await DCAHub.connect(superAdmin).grantRole(await DCAHub.PLATFORM_WITHDRAW_ROLE(), DCAFeeManager.address);
     await DCAFeeManager.connect(superAdmin).grantRole(await DCAFeeManager.ADMIN_ROLE(), allowed.address);
     await swapperRegistry.connect(superAdmin).allowSwappers([transformerRegistry.address]);
+    await DCAHubSwapper.connect(superAdmin).grantRole(await DCAHubSwapper.SWAP_EXECUTION_ROLE(), swapper.address);
 
     WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
     USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);

--- a/test/integration/DCAHubCompanion/multi-call.spec.ts
+++ b/test/integration/DCAHubCompanion/multi-call.spec.ts
@@ -73,8 +73,9 @@ contract('Multicall', () => {
     WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
     USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);
 
-    // Allow tokens
+    // Allow tokens and swapper
     await DCAHub.connect(governor).setAllowedTokens([WETH_ADDRESS, USDC_ADDRESS], [true, true]);
+    await DCAHubSwapper.connect(governor).grantRole(await DCAHubSwapper.SWAP_EXECUTION_ROLE(), swapper.address);
 
     // Send tokens from whales, to our users
     await distributeTokensToUsers();

--- a/test/integration/DCAHubSwapper/multi-pair-swap-with-dex.spec.ts
+++ b/test/integration/DCAHubSwapper/multi-pair-swap-with-dex.spec.ts
@@ -74,6 +74,8 @@ contract('Multi pair swap with DEX', () => {
     await DCAHub.connect(governor).addSwapIntervalsToAllowedList([SwapInterval.ONE_MINUTE.seconds]);
     //We are setting a very high fee, so that there is a surplus in both reward and toProvide tokens
     await DCAHub.connect(timelock).setSwapFee(50000); // 5%
+    // Allow swapper
+    await DCAHubSwapper.connect(governor).grantRole(await DCAHubSwapper.SWAP_EXECUTION_ROLE(), cindy.address);
 
     WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
     USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);

--- a/test/integration/DCAHubSwapper/single-pair-swap-with-dex.spec.ts
+++ b/test/integration/DCAHubSwapper/single-pair-swap-with-dex.spec.ts
@@ -74,6 +74,8 @@ contract('Single pair swap with DEX', () => {
     await DCAHub.connect(governor).addSwapIntervalsToAllowedList([SwapInterval.ONE_MINUTE.seconds]);
     //We are setting a very high fee, so that there is a surplus in both reward and toProvide tokens
     await DCAHub.connect(timelock).setSwapFee(20000); // 2%
+    // Allow swapper
+    await DCAHubSwapper.connect(governor).grantRole(await DCAHubSwapper.SWAP_EXECUTION_ROLE(), cindy.address);
 
     WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
     USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);

--- a/test/integration/DCAHubSwapper/swap-for-caller.spec.ts
+++ b/test/integration/DCAHubSwapper/swap-for-caller.spec.ts
@@ -66,6 +66,9 @@ contract('Swap for caller', () => {
     // Allow one minute interval
     await DCAHub.connect(governor).addSwapIntervalsToAllowedList([SwapInterval.ONE_MINUTE.seconds]);
 
+    // Allow swapper
+    await DCAHubSwapper.connect(governor).grantRole(await DCAHubSwapper.SWAP_EXECUTION_ROLE(), swapper.address);
+
     WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
     USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);
 

--- a/test/integration/V2Migration/position-migrator.spec.ts
+++ b/test/integration/V2Migration/position-migrator.spec.ts
@@ -171,7 +171,7 @@ contract('PositionMigrator', () => {
     const DCAHubSwapperFactory: DCAHubSwapper__factory = await ethers.getContractFactory(
       'contracts/DCAHubSwapper/DCAHubSwapper.sol:DCAHubSwapper'
     );
-    const DCAHubSwapper = await DCAHubSwapperFactory.deploy(constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS, []);
+    const DCAHubSwapper = await DCAHubSwapperFactory.deploy(constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS, [swapper.address]);
     await WETH.connect(swapper).approve(DCAHubSwapper.address, constants.MAX_UINT_256);
     await DCAHubSwapper.connect(swapper).swapForCaller(
       hub.address,

--- a/test/unit/DCAHubSwapper/dca-hub-swapper-swap-handler.spec.ts
+++ b/test/unit/DCAHubSwapper/dca-hub-swapper-swap-handler.spec.ts
@@ -111,11 +111,26 @@ contract('DCAHubSwapperSwapHandler', () => {
       });
       then('reverts with message', async () => {
         await behaviours.txShouldRevertWithMessage({
-          contract: DCAHubSwapperSwapHandler,
+          contract: DCAHubSwapperSwapHandler.connect(swapExecutioner),
           func: 'swapForCaller',
           args: [DCAHub.address, tokens, INDEXES, [MIN_OUTPUT, MIN_OUTPUT], [MAX_INPUT, MAX_INPUT], SOME_RANDOM_ADDRESS, constants.MAX_UINT_256],
           message: 'RewardNotEnough',
         });
+      });
+      behaviours.shouldBeExecutableOnlyByRole({
+        contract: () => DCAHubSwapperSwapHandler,
+        funcAndSignature: 'swapForCaller',
+        params: () => [
+          DCAHub.address,
+          tokens,
+          INDEXES,
+          [MIN_OUTPUT, MIN_OUTPUT],
+          [MAX_INPUT, MAX_INPUT],
+          SOME_RANDOM_ADDRESS,
+          constants.MAX_UINT_256,
+        ],
+        addressWithRole: () => swapExecutioner,
+        role: () => swapExecutionRole,
       });
     });
     when('hub asks for more than maximum input', () => {
@@ -142,7 +157,7 @@ contract('DCAHubSwapperSwapHandler', () => {
       });
       then('reverts with message', async () => {
         await behaviours.txShouldRevertWithMessage({
-          contract: DCAHubSwapperSwapHandler,
+          contract: DCAHubSwapperSwapHandler.connect(swapExecutioner),
           func: 'swapForCaller',
           args: [DCAHub.address, tokens, INDEXES, [MIN_OUTPUT, MIN_OUTPUT], [MAX_INPUT, MAX_INPUT], SOME_RANDOM_ADDRESS, constants.MAX_UINT_256],
           message: 'ToProvideIsTooMuch',
@@ -222,6 +237,24 @@ contract('DCAHubSwapperSwapHandler', () => {
           }),
       });
     });
+    behaviours.shouldBeExecutableOnlyByRole({
+      contract: () => DCAHubSwapperSwapHandler,
+      funcAndSignature: 'swapWithDexes',
+      params: () => [
+        {
+          hub: DCAHub.address,
+          tokens: tokens,
+          pairsToSwap: INDEXES,
+          allowanceTargets: [{ token: tokenA.address, allowanceTarget: DEX, minAllowance: 2000 }],
+          swappers: [DEX],
+          executions: [{ swapData: BYTES, swapperIndex: 0 }],
+          leftoverRecipient: recipient.address,
+          deadline: constants.MAX_UINT_256,
+        },
+      ],
+      addressWithRole: () => swapExecutioner,
+      role: () => swapExecutionRole,
+    });
   });
   describe('swapWithDexesForMean', () => {
     const BYTES = ethers.utils.randomBytes(10);
@@ -274,6 +307,24 @@ contract('DCAHubSwapperSwapHandler', () => {
             },
           }),
       });
+    });
+    behaviours.shouldBeExecutableOnlyByRole({
+      contract: () => DCAHubSwapperSwapHandler,
+      funcAndSignature: 'swapWithDexesForMean',
+      params: () => [
+        {
+          hub: DCAHub.address,
+          tokens: tokens,
+          pairsToSwap: INDEXES,
+          allowanceTargets: [{ token: tokenA.address, allowanceTarget: DEX, minAllowance: 2000 }],
+          swappers: [DEX],
+          executions: [{ swapData: BYTES, swapperIndex: 0 }],
+          leftoverRecipient: recipient.address,
+          deadline: constants.MAX_UINT_256,
+        },
+      ],
+      addressWithRole: () => swapExecutioner,
+      role: () => swapExecutionRole,
     });
   });
   describe('DCAHubSwapCall', () => {
@@ -469,7 +520,7 @@ contract('DCAHubSwapperSwapHandler', () => {
     when('deadline has expired', () => {
       then('reverts with message', async () => {
         await behaviours.txShouldRevertWithMessage({
-          contract: DCAHubSwapperSwapHandler,
+          contract: DCAHubSwapperSwapHandler.connect(swapExecutioner),
           func,
           args: args(),
           message: 'Transaction too old',


### PR DESCRIPTION
We are now making it so that swaps in the DCASwapper can only be executed by addressed with the `SWAP_EXECUTION_ROLE` role