### PR TITLE
refactor: change swappers permissions

### DIFF
--- a/contracts/mocks/DCAHubSwapper/DCAHubSwapper.sol
+++ b/contracts/mocks/DCAHubSwapper/DCAHubSwapper.sol
@@ -15,9 +15,10 @@ contract DCAHubSwapperMock is DCAHubSwapper {
 
   constructor(
     address _swapperRegistry,
-    address _admin,
+    address _superAdmin,
+    address[] memory _initialAdmins,
     address[] memory _initialSwapExecutors
-  ) DCAHubSwapper(_swapperRegistry, _admin, _initialSwapExecutors) {}
+  ) DCAHubSwapper(_swapperRegistry, _superAdmin, _initialAdmins, _initialSwapExecutors) {}
 
   function maxApproveSpenderCalls() external view returns (MaxApproveSpenderCall[] memory) {
     return _maxApproveSpenderCalls;

--- a/deploy/002_swapper.ts
+++ b/deploy/002_swapper.ts
@@ -15,8 +15,8 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     contract: 'contracts/DCAHubSwapper/DCAHubSwapper.sol:DCAHubSwapper',
     bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address[]'],
-      values: [swapperRegistry.address, governor, []],
+      types: ['address', 'address', 'address[]', 'address[]'],
+      values: [swapperRegistry.address, governor, [governor], []],
     },
     log: !process.env.TEST,
   });

--- a/test/integration/V2Migration/position-migrator.spec.ts
+++ b/test/integration/V2Migration/position-migrator.spec.ts
@@ -171,7 +171,7 @@ contract('PositionMigrator', () => {
     const DCAHubSwapperFactory: DCAHubSwapper__factory = await ethers.getContractFactory(
       'contracts/DCAHubSwapper/DCAHubSwapper.sol:DCAHubSwapper'
     );
-    const DCAHubSwapper = await DCAHubSwapperFactory.deploy(constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS, [swapper.address]);
+    const DCAHubSwapper = await DCAHubSwapperFactory.deploy(constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS, [], [swapper.address]);
     await WETH.connect(swapper).approve(DCAHubSwapper.address, constants.MAX_UINT_256);
     await DCAHubSwapper.connect(swapper).swapForCaller(
       hub.address,


### PR DESCRIPTION
We are now making a small change. We are bringing back the "super admin role" so now everything is consistent with the rest of the permissioned contracts, and we are setting it as its own admin