### PR TITLE
feat: add revoke and send dust

### DIFF
--- a/contracts/DCAHubSwapper/DCAHubSwapper.sol
+++ b/contracts/DCAHubSwapper/DCAHubSwapper.sol
@@ -2,12 +2,12 @@
 pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/access/AccessControl.sol';
-import '@mean-finance/swappers/solidity/contracts/SwapAdapter.sol';
+import '@mean-finance/swappers/solidity/contracts/extensions/GetBalances.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '../interfaces/IDCAHubSwapper.sol';
 import './utils/DeadlineValidation.sol';
 
-contract DCAHubSwapper is DeadlineValidation, AccessControl, SwapAdapter, IDCAHubSwapper {
+contract DCAHubSwapper is DeadlineValidation, AccessControl, GetBalances, IDCAHubSwapper {
   enum SwapPlan {
     // Used only for tests
     NONE,
@@ -121,6 +121,20 @@ contract DCAHubSwapper is DeadlineValidation, AccessControl, SwapAdapter, IDCAHu
     returns (IDCAHub.SwapInfo memory)
   {
     return _swapWithDexes(_parameters, true);
+  }
+
+  /// @inheritdoc IDCAHubSwapper
+  function revokeAllowances(RevokeAction[] calldata _revokeActions) external onlyRole(ADMIN_ROLE) {
+    _revokeAllowances(_revokeActions);
+  }
+
+  /// @inheritdoc IDCAHubSwapper
+  function sendDust(
+    address _token,
+    uint256 _amount,
+    address _recipient
+  ) external onlyRole(ADMIN_ROLE) {
+    _sendToRecipient(_token, _amount, _recipient);
   }
 
   function _swapWithDexes(SwapWithDexesParams calldata _parameters, bool _sendToProvideLeftoverToHub)

--- a/contracts/interfaces/IDCAHubSwapper.sol
+++ b/contracts/interfaces/IDCAHubSwapper.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.7 <0.9.0;
 
 import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHub.sol';
 import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHubSwapCallee.sol';
+import '@mean-finance/swappers/solidity/interfaces/ISwapAdapter.sol';
 import '@mean-finance/swappers/solidity/contracts/extensions/Shared.sol';
 
 interface IDCAHubSwapper is IDCAHubSwapCallee {
@@ -45,7 +46,8 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
 
   /**
    * @notice Executes a swap for the caller, by sending them the reward, and taking from them the needed tokens
-   * @dev Will revert:
+   * @dev Can only be called by user with appropriate role
+   *      Will revert:
    *      - With RewardNotEnough if the minimum output is not met
    *      - With ToProvideIsTooMuch if the hub swap requires more than the given maximum input
    * @param hub The address of the DCAHub
@@ -69,6 +71,7 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
 
   /**
    * @notice Executes a swap with the given swappers, and sends all unspent tokens to the given recipient
+   * @dev Can only be called by user with appropriate role
    * @return The information about the executed swap
    */
   function swapWithDexes(SwapWithDexesParams calldata parameters) external payable returns (IDCAHub.SwapInfo memory);
@@ -78,7 +81,28 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
    *         swap with the given swappers, but sends some of the unspent tokens back to the hub. This means that they
    *         will be considered part of the protocol's balance. Unspent tokens that were given as reward will be
    *         sent to the provided recipient
+   * @dev Can only be called by user with appropriate role
    * @return The information about the executed swap
    */
   function swapWithDexesForMean(SwapWithDexesParams calldata parameters) external payable returns (IDCAHub.SwapInfo memory);
+
+  /**
+   * @notice Revokes ERC20 allowances for the given spenders
+   * @dev Can only be called an admin
+   * @param revokeActions The spenders and tokens to revoke
+   */
+  function revokeAllowances(ISwapAdapter.RevokeAction[] calldata revokeActions) external;
+
+  /**
+   * @notice Sends the given token to the recipient
+   * @dev Can only be called an admin
+   * @param token The token to send to the recipient (can be an ERC20 or the protocol token)
+   * @param amount The amount to transfer to the recipient
+   * @param recipient The address of the recipient
+   */
+  function sendDust(
+    address token,
+    uint256 amount,
+    address recipient
+  ) external;
 }

--- a/contracts/mocks/DCAHubSwapper/DCAHubSwapper.sol
+++ b/contracts/mocks/DCAHubSwapper/DCAHubSwapper.sol
@@ -11,7 +11,15 @@ contract DCAHubSwapperMock is DCAHubSwapper {
     uint256 minAllowance;
   }
 
+  struct SendToRecipientCall {
+    address token;
+    uint256 amount;
+    address recipient;
+  }
+
   MaxApproveSpenderCall[] internal _maxApproveSpenderCalls;
+  SendToRecipientCall[] internal _sendToRecipientCalls;
+  RevokeAction[][] internal _revokeCalls;
 
   constructor(
     address _swapperRegistry,
@@ -24,6 +32,14 @@ contract DCAHubSwapperMock is DCAHubSwapper {
     return _maxApproveSpenderCalls;
   }
 
+  function sendToRecipientCalls() external view returns (SendToRecipientCall[] memory) {
+    return _sendToRecipientCalls;
+  }
+
+  function revokeAllowancesCalls() external view returns (RevokeAction[][] memory) {
+    return _revokeCalls;
+  }
+
   function _maxApproveSpenderIfNeeded(
     IERC20 _token,
     address _spender,
@@ -32,6 +48,24 @@ contract DCAHubSwapperMock is DCAHubSwapper {
   ) internal override {
     _maxApproveSpenderCalls.push(MaxApproveSpenderCall(_token, _spender, _alreadyValidatedSpender, _minAllowance));
     super._maxApproveSpenderIfNeeded(_token, _spender, _alreadyValidatedSpender, _minAllowance);
+  }
+
+  function _revokeAllowances(RevokeAction[] calldata _revokeActions) internal override {
+    _revokeCalls.push();
+    uint256 _currentCall = _revokeCalls.length - 1;
+    for (uint256 i; i < _revokeActions.length; i++) {
+      _revokeCalls[_currentCall].push(_revokeActions[i]);
+    }
+    super._revokeAllowances(_revokeActions);
+  }
+
+  function _sendToRecipient(
+    address _token,
+    uint256 _amount,
+    address _recipient
+  ) internal override {
+    _sendToRecipientCalls.push(SendToRecipientCall(_token, _amount, _recipient));
+    super._sendToRecipient(_token, _amount, _recipient);
   }
 
   function isSwapExecutorEmpty() external view returns (bool) {

--- a/test/unit/DCAHubSwapper/dca-hub-swapper.spec.ts
+++ b/test/unit/DCAHubSwapper/dca-hub-swapper.spec.ts
@@ -338,6 +338,52 @@ contract('DCAHubSwapper', () => {
       role: () => swapExecutionRole,
     });
   });
+  describe('revokeAllowances', () => {
+    when('allowance is revoked', () => {
+      given(async () => {
+        await DCAHubSwapper.connect(admin).revokeAllowances([{ spender: recipient.address, tokens: [tokenA.address] }]);
+      });
+      then('revoke was called correctly', async () => {
+        const calls = await DCAHubSwapper.revokeAllowancesCalls();
+        expect(calls).to.have.lengthOf(1);
+        expect(calls[0]).to.have.lengthOf(1);
+        expect((calls[0][0] as any).spender).to.equal(recipient.address);
+        expect((calls[0][0] as any).tokens).to.eql([tokenA.address]);
+      });
+    });
+    behaviours.shouldBeExecutableOnlyByRole({
+      contract: () => DCAHubSwapper,
+      funcAndSignature: 'revokeAllowances',
+      params: [[]],
+      addressWithRole: () => admin,
+      role: () => adminRole,
+    });
+  });
+  describe('sendDust', () => {
+    given(async () => {
+      await tokenA.mint(DCAHubSwapper.address, 10000);
+    });
+    when('function is called', () => {
+      given(async () => {
+        await DCAHubSwapper.connect(admin).sendDust(tokenA.address, 10000, recipient.address);
+      });
+      then('send to recipient was called correctly', async () => {
+        const calls = await DCAHubSwapper.sendToRecipientCalls();
+        expect(calls).to.have.lengthOf(1);
+        expect(calls).to.have.lengthOf(1);
+        expect(calls[0].token).to.equal(tokenA.address);
+        expect(calls[0].amount).to.equal(10000);
+        expect(calls[0].recipient).to.equal(recipient.address);
+      });
+    });
+    behaviours.shouldBeExecutableOnlyByRole({
+      contract: () => DCAHubSwapper,
+      funcAndSignature: 'sendDust',
+      params: () => [tokenA.address, 10000, recipient.address],
+      addressWithRole: () => admin,
+      role: () => adminRole,
+    });
+  });
   describe('DCAHubSwapCall', () => {
     let tokensInSwap: { token: string; toProvide: BigNumberish; reward: BigNumberish; platformFee: BigNumberish }[];
     let hub: SignerWithAddress;


### PR DESCRIPTION
We are now adding `revokeAllowances` and `sendDust` to the DCAHubSwapper