### PR TITLE
feat: add legacy swap for caller

### DIFF
--- a/contracts/interfaces/IDCAHubSwapper.sol
+++ b/contracts/interfaces/IDCAHubSwapper.sol
@@ -5,6 +5,7 @@ import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHub.sol';
 import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHubSwapCallee.sol';
 import '@mean-finance/swappers/solidity/interfaces/ISwapAdapter.sol';
 import '@mean-finance/swappers/solidity/contracts/extensions/Shared.sol';
+import './ILegacyDCAHub.sol';
 
 interface IDCAHubSwapper is IDCAHubSwapCallee {
   /// @notice Parameters to execute a swap with dexes
@@ -57,6 +58,24 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
     uint256 deadline;
   }
 
+  /// @notice Parameters to execute a swap for caller
+  struct LegacySwapForCallerParams {
+    // The address of the DCAHub
+    ILegacyDCAHub hub;
+    // The tokens involved in the swap
+    address[] tokens;
+    // The pairs to swap
+    ILegacyDCAHub.PairIndexes[] pairsToSwap;
+    // The minimum amount of tokens to receive as part of the swap
+    uint256[] minimumOutput;
+    // The maximum amount of tokens to provide as part of the swap
+    uint256[] maximumInput;
+    // Address that will receive all the tokens from the swap
+    address recipient;
+    // Deadline when the swap becomes invalid
+    uint256 deadline;
+  }
+
   /// @notice Thrown when the reward is less that the specified minimum
   error RewardNotEnough();
 
@@ -75,6 +94,16 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
    * @return The information about the executed swap
    */
   function swapForCaller(SwapForCallerParams calldata parameters) external payable returns (IDCAHub.SwapInfo memory);
+
+  /**
+   * @notice Executes a swap for the caller, by sending them the reward, and taking from them the needed tokens
+   * @dev Can only be called by user with appropriate role
+   *      Will revert:
+   *      - With RewardNotEnough if the minimum output is not met
+   *      - With ToProvideIsTooMuch if the hub swap requires more than the given maximum input
+   * @return The information about the executed swap
+   */
+  function legacySwapForCaller(LegacySwapForCallerParams calldata parameters) external payable returns (ILegacyDCAHub.SwapInfo memory);
 
   /**
    * @notice Executes a swap with the given swappers, and sends all unspent tokens to the given recipient

--- a/contracts/interfaces/ILegacyDCAHub.sol
+++ b/contracts/interfaces/ILegacyDCAHub.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+interface ILegacyDCAHub {
+  /// @notice Information about a swap
+  struct SwapInfo {
+    // The tokens involved in the swap
+    TokenInSwap[] tokens;
+    // The pairs involved in the swap
+    PairInSwap[] pairs;
+  }
+
+  /// @notice Information about a token's role in a swap
+  struct TokenInSwap {
+    // The token's address
+    address token;
+    // How much will be given of this token as a reward
+    uint256 reward;
+    // How much of this token needs to be provided by swapper
+    uint256 toProvide;
+    // How much of this token will be paid to the platform
+    uint256 platformFee;
+  }
+
+  /// @notice Information about a pair in a swap
+  struct PairInSwap {
+    // The address of one of the tokens
+    address tokenA;
+    // The address of the other token
+    address tokenB;
+    // How much is 1 unit of token A when converted to B
+    uint256 ratioAToB;
+    // How much is 1 unit of token B when converted to A
+    uint256 ratioBToA;
+    // The swap intervals involved in the swap, represented as a byte
+    bytes1 intervalsInSwap;
+  }
+
+  /// @notice A pair of tokens, represented by their indexes in an array
+  struct PairIndexes {
+    // The index of the token A
+    uint8 indexTokenA;
+    // The index of the token B
+    uint8 indexTokenB;
+  }
+
+  /**
+   * @notice Returns all information related to the next swap
+   * @dev Will revert with:
+   *      - With InvalidTokens if tokens are not sorted, or if there are duplicates
+   *      - With InvalidPairs if pairs are not sorted (first by indexTokenA and then indexTokenB), or if indexTokenA >= indexTokenB for any pair
+   * @param tokens The tokens involved in the next swap
+   * @param pairs The pairs that you want to swap. Each element of the list points to the index of the token in the tokens array
+   * @return swapInformation The information about the next swap
+   */
+  function getNextSwapInfo(address[] calldata tokens, PairIndexes[] calldata pairs) external view returns (SwapInfo memory swapInformation);
+
+  /**
+   * @notice Executes a flash swap
+   * @dev Will revert with:
+   *      - With InvalidTokens if tokens are not sorted, or if there are duplicates
+   *      - With InvalidPairs if pairs are not sorted (first by indexTokenA and then indexTokenB), or if indexTokenA >= indexTokenB for any pair
+   *      - With Paused if swaps are paused by protocol
+   *      - With NoSwapsToExecute if there are no swaps to execute for the given pairs
+   *      - With LiquidityNotReturned if the required tokens were not back during the callback
+   * @param tokens The tokens involved in the next swap
+   * @param pairsToSwap The pairs that you want to swap. Each element of the list points to the index of the token in the tokens array
+   * @param rewardRecipient The address to send the reward to
+   * @param callbackHandler Address to call for callback (and send the borrowed tokens to)
+   * @param borrow How much to borrow of each of the tokens in tokens. The amount must match the position of the token in the tokens array
+   * @param callbackData Bytes to send to the caller during the callback
+   * @return Information about the executed swap
+   */
+  function swap(
+    address[] calldata tokens,
+    PairIndexes[] calldata pairsToSwap,
+    address rewardRecipient,
+    address callbackHandler,
+    uint256[] calldata borrow,
+    bytes calldata callbackData
+  ) external returns (SwapInfo memory);
+}

--- a/deploy/002_swapper.ts
+++ b/deploy/002_swapper.ts
@@ -19,6 +19,9 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
       values: [swapperRegistry.address, msig, [msig], []],
     },
     log: !process.env.TEST,
+    overrides: {
+      gasLimit: 6_000_000,
+    },
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@0xged/hardhat-deploy": "0.11.5",
-    "@mean-finance/dca-v2-core": "2.2.0-rc3",
+    "@mean-finance/dca-v2-core": "2.2.0-rc4",
     "@mean-finance/deterministic-factory": "1.3.1",
     "@mean-finance/swappers": "1.0.0-rc8",
     "@openzeppelin/contracts": "4.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,10 +1559,10 @@
     "@uniswap/v3-periphery" "1.2.0"
     base64-sol "1.0.1"
 
-"@mean-finance/dca-v2-core@2.2.0-rc3":
-  version "2.2.0-rc3"
-  resolved "https://registry.yarnpkg.com/@mean-finance/dca-v2-core/-/dca-v2-core-2.2.0-rc3.tgz#76142b0f77559cf97c272113bd0510d8fba5f740"
-  integrity sha512-+OFVpEb0Q5Il+4XOQw9d0kGztmPgNT4roTGaX0InTcx5Ws8hgsijcKf6oLPOr72WS+VaSBMthLO5KqU31x0wEA==
+"@mean-finance/dca-v2-core@2.2.0-rc4":
+  version "2.2.0-rc4"
+  resolved "https://registry.yarnpkg.com/@mean-finance/dca-v2-core/-/dca-v2-core-2.2.0-rc4.tgz#4fb77690b76389916e93419f170794cb09069775"
+  integrity sha512-t5VXRZKSRsU+XLRHpPyS+eYZQFlwCk0zAoG1rGM6I28PaD0ANO8hURkhiC+L+G1vT6jbf0UuxixN628mrYlcow==
   dependencies:
     "@0xged/hardhat-deploy" "0.11.5"
     "@mean-finance/deterministic-factory" "1.3.1"


### PR DESCRIPTION
We are now adding a way to execute `swapForCaller` for legacy hubs