### PR TITLE
refactor: consider privilege on seconds until next swap

### DIFF
--- a/contracts/DCAHubCompanion/DCAHubCompanionLibrariesHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionLibrariesHandler.sol
@@ -13,7 +13,11 @@ abstract contract DCAHubCompanionLibrariesHandler is IDCAHubCompanionLibrariesHa
   }
 
   /// @inheritdoc IDCAHubCompanionLibrariesHandler
-  function secondsUntilNextSwap(IDCAHub _hub, Pair[] calldata _pairs) external view returns (uint256[] memory) {
-    return SecondsUntilNextSwap.secondsUntilNextSwap(_hub, _pairs);
+  function secondsUntilNextSwap(
+    IDCAHub _hub,
+    Pair[] calldata _pairs,
+    bool _calculatePrivilegedAvailability
+  ) external view returns (uint256[] memory) {
+    return SecondsUntilNextSwap.secondsUntilNextSwap(_hub, _pairs, _calculatePrivilegedAvailability);
   }
 }

--- a/contracts/interfaces/IDCAHubCompanion.sol
+++ b/contracts/interfaces/IDCAHubCompanion.sol
@@ -24,9 +24,15 @@ interface IDCAHubCompanionLibrariesHandler {
    * @dev Tokens in pairs may be passed in either tokenA/tokenB or tokenB/tokenA order
    * @param hub The address of the DCAHub
    * @param pairs Pairs to check
+   * @param calculatePrivilegedAvailability Some accounts get privileged availability and can execute swaps before others. This flag provides
+   *        the possibility to calculate the seconds until next swap for privileged and non-privileged accounts
    * @return The amount of seconds until next swap for each of the pairs
    */
-  function secondsUntilNextSwap(IDCAHub hub, Pair[] calldata pairs) external view returns (uint256[] memory);
+  function secondsUntilNextSwap(
+    IDCAHub hub,
+    Pair[] calldata pairs,
+    bool calculatePrivilegedAvailability
+  ) external view returns (uint256[] memory);
 }
 
 interface IDCAHubCompanionHubProxyHandler {

--- a/contracts/libraries/SecondsUntilNextSwap.sol
+++ b/contracts/libraries/SecondsUntilNextSwap.sol
@@ -6,19 +6,26 @@ import '@mean-finance/dca-v2-core/contracts/libraries/TokenSorting.sol';
 import '@mean-finance/dca-v2-core/contracts/libraries/Intervals.sol';
 import '../interfaces/ISharedTypes.sol';
 
-/// @title Seconds Until Next Swap Library
-/// @notice Provides functions to calculate how long users have to wait until a pair's next swap is available
+/**
+ * @title Seconds Until Next Swap Library
+ * @notice Provides functions to calculate how long users have to wait until a pair's next swap is available
+ */
 library SecondsUntilNextSwap {
-  /// @notice Returns how many seconds left until the next swap is available for a specific pair
-  /// @dev _tokenA and _tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
-  /// @param _hub The address of the DCA Hub
-  /// @param _tokenA One of the pair's tokens
-  /// @param _tokenB The other of the pair's tokens
-  /// @return The amount of seconds until next swap. Returns 0 if a swap can already be executed and max(uint256) if there is nothing to swap
+  /**
+   * @notice Returns how many seconds left until the next swap is available for a specific pair
+   * @dev _tokenA and _tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
+   * @param _hub The address of the DCA Hub
+   * @param _tokenA One of the pair's tokens
+   * @param _tokenB The other of the pair's tokens
+   * @param _calculatePrivilegedAvailability Some accounts get privileged availability and can execute swaps before others. This flag provides
+   *        the possibility to calculate the seconds until next swap for privileged and non-privileged accounts
+   * @return The amount of seconds until next swap. Returns 0 if a swap can already be executed and max(uint256) if there is nothing to swap
+   */
   function secondsUntilNextSwap(
     IDCAHub _hub,
     address _tokenA,
-    address _tokenB
+    address _tokenB,
+    bool _calculatePrivilegedAvailability
   ) internal view returns (uint256) {
     (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
     bytes1 _activeIntervals = _hub.activeSwapIntervals(__tokenA, __tokenB);
@@ -29,6 +36,10 @@ library SecondsUntilNextSwap {
         (, uint224 _nextAmountToSwapAToB, uint32 _lastSwappedAt, uint224 _nextAmountToSwapBToA) = _hub.swapData(_tokenA, _tokenB, _mask);
         uint32 _swapInterval = Intervals.maskToInterval(_mask);
         uint256 _nextAvailable = ((_lastSwappedAt / _swapInterval) + 1) * _swapInterval;
+        if (!_calculatePrivilegedAvailability) {
+          // If the caller does not have privileges, then they will have to wait a little more to execute swaps
+          _nextAvailable += _swapInterval / 3;
+        }
         if (_nextAmountToSwapAToB > 0 || _nextAmountToSwapBToA > 0) {
           if (_nextAvailable <= block.timestamp) {
             return _smallerIntervalBlocking;
@@ -44,15 +55,23 @@ library SecondsUntilNextSwap {
     return type(uint256).max;
   }
 
-  /// @notice Returns how many seconds left until the next swap is available for a list of pairs
-  /// @dev Tokens in pairs may be passed in either tokenA/tokenB or tokenB/tokenA order
-  /// @param _hub The address of the DCA Hub
-  /// @param _pairs Pairs to check
-  /// @return _seconds The amount of seconds until next swap for each of the pairs
-  function secondsUntilNextSwap(IDCAHub _hub, Pair[] calldata _pairs) internal view returns (uint256[] memory _seconds) {
+  /**
+   * @notice Returns how many seconds left until the next swap is available for a list of pairs
+   * @dev Tokens in pairs may be passed in either tokenA/tokenB or tokenB/tokenA order
+   * @param _hub The address of the DCA Hub
+   * @param _pairs Pairs to check
+   * @return _seconds The amount of seconds until next swap for each of the pairs
+   * @param _calculatePrivilegedAvailability Some accounts get privileged availability and can execute swaps before others. This flag provides
+   *        the possibility to calculate the seconds until next swap for privileged and non-privileged accounts
+   */
+  function secondsUntilNextSwap(
+    IDCAHub _hub,
+    Pair[] calldata _pairs,
+    bool _calculatePrivilegedAvailability
+  ) internal view returns (uint256[] memory _seconds) {
     _seconds = new uint256[](_pairs.length);
     for (uint256 i; i < _pairs.length; i++) {
-      _seconds[i] = secondsUntilNextSwap(_hub, _pairs[i].tokenA, _pairs[i].tokenB);
+      _seconds[i] = secondsUntilNextSwap(_hub, _pairs[i].tokenA, _pairs[i].tokenB, _calculatePrivilegedAvailability);
     }
   }
 }

--- a/contracts/mocks/libraries/SecondsUntilNextSwap.sol
+++ b/contracts/mocks/libraries/SecondsUntilNextSwap.sol
@@ -7,12 +7,17 @@ contract SecondsUntilNextSwapMock {
   function secondsUntilNextSwap(
     IDCAHub _hub,
     address _tokenA,
-    address _tokenB
+    address _tokenB,
+    bool _calculatePrivilegedAvailability
   ) external view returns (uint256) {
-    return SecondsUntilNextSwap.secondsUntilNextSwap(_hub, _tokenA, _tokenB);
+    return SecondsUntilNextSwap.secondsUntilNextSwap(_hub, _tokenA, _tokenB, _calculatePrivilegedAvailability);
   }
 
-  function secondsUntilNextSwap(IDCAHub _hub, Pair[] calldata _pairs) external view returns (uint256[] memory) {
-    return SecondsUntilNextSwap.secondsUntilNextSwap(_hub, _pairs);
+  function secondsUntilNextSwap(
+    IDCAHub _hub,
+    Pair[] calldata _pairs,
+    bool _calculatePrivilegedAvailability
+  ) external view returns (uint256[] memory) {
+    return SecondsUntilNextSwap.secondsUntilNextSwap(_hub, _pairs, _calculatePrivilegedAvailability);
   }
 }


### PR DESCRIPTION
We are now taking into consideration the new privileged role when calculating `secondsUntilNextSwap`