### PR TITLE
feat: permissions-functions

### DIFF
--- a/contracts/DCAStrategies/DCAStrategies/DCAStrategies.sol
+++ b/contracts/DCAStrategies/DCAStrategies/DCAStrategies.sol
@@ -7,5 +7,5 @@ import './DCAStrategiesPositionsHandler.sol';
 import '../../interfaces/IDCAStrategies.sol';
 
 contract DCAStrategies is DCAStrategiesManagementHandler, DCAStrategiesPermissionsHandler, DCAStrategiesPositionsHandler, IDCAStrategies {
-  constructor() ERC721('Mean Finance - DCA Strategy Position', 'MF-DCA-STRAT-P') {}
+  constructor(address _governor, IDCAHubPositionDescriptor _descriptor) DCAStrategiesPermissionsHandler(_governor, _descriptor) {}
 }

--- a/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPermissionsHandler.sol
+++ b/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPermissionsHandler.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.7 <0.9.0;
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 import '@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol';
 import '../../interfaces/IDCAStrategies.sol';
+import '../../libraries/PermissionMath.sol';
 import '../../utils/Governable.sol';
 
 abstract contract DCAStrategiesPermissionsHandler is IDCAStrategiesPermissionsHandler, ERC721, EIP712 {

--- a/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPermissionsHandler.sol
+++ b/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPermissionsHandler.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 import '../../interfaces/IDCAStrategies.sol';
+import '../../utils/Governable.sol';
 
 abstract contract DCAStrategiesPermissionsHandler is IDCAStrategiesPermissionsHandler, ERC721 {
   /// @inheritdoc IDCAStrategiesPermissionsHandler

--- a/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPermissionsHandler.sol
+++ b/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPermissionsHandler.sol
@@ -2,10 +2,13 @@
 pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
+import '@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol';
 import '../../interfaces/IDCAStrategies.sol';
 import '../../utils/Governable.sol';
 
-abstract contract DCAStrategiesPermissionsHandler is IDCAStrategiesPermissionsHandler, ERC721 {
+abstract contract DCAStrategiesPermissionsHandler is IDCAStrategiesPermissionsHandler, ERC721, EIP712 {
+  constructor() EIP712('Mean Finance - DCA Strategy Position', '1') {}
+
   /// @inheritdoc IDCAStrategiesPermissionsHandler
   // solhint-disable-next-line func-name-mixedcase
   function PERMIT_TYPEHASH() external pure override returns (bytes32) {}

--- a/contracts/interfaces/IDCAStrategies.sol
+++ b/contracts/interfaces/IDCAStrategies.sol
@@ -35,6 +35,37 @@ interface IDCAStrategiesManagementHandler {
 
 interface IDCAStrategiesPermissionsHandler is IERC721, IERC721BasicEnumerable {
   /**
+   * @notice Emitted when permissions for a token are modified
+   * @param tokenId The id of the token
+   * @param permissions The set of permissions that were updated
+   */
+  event Modified(uint256 tokenId, IDCAStrategies.PermissionSet[] permissions);
+
+  /**
+   * @notice Emitted when the address for a new descritor is set
+   * @param descriptor The new descriptor contract
+   */
+  event NFTDescriptorSet(IDCAHubPositionDescriptor descriptor);
+
+  /// @notice Thrown when a user tries to set the hub, once it was already set
+  error HubAlreadySet();
+
+  /// @notice Thrown when a user provides a zero address when they shouldn't
+  error ZeroAddress();
+
+  /// @notice Thrown when a user calls a method that can only be executed by the hub
+  error OnlyHubCanExecute();
+
+  /// @notice Thrown when a user tries to modify permissions for a token they do not own
+  error NotOwner();
+
+  /// @notice Thrown when a user tries to execute a permit with an expired deadline
+  error ExpiredDeadline();
+
+  /// @notice Thrown when a user tries to execute a permit with an invalid signature
+  error InvalidSignature();
+
+  /**
    * @notice The permit typehash used in the permit signature
    * @return The typehash for the permit
    */

--- a/contracts/interfaces/utils/IGovernable.sol
+++ b/contracts/interfaces/utils/IGovernable.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* solhint-disable wonderland/non-state-vars-leading-underscore */
+pragma solidity >=0.8.7 <0.9.0;
+
+/**
+ * @title A contract that manages a "governor" role
+ */
+interface IGovernable {
+  /// @notice Thrown when trying to set the zero address as governor
+  error GovernorIsZeroAddress();
+
+  /// @notice Thrown when trying to execute an action that only the governor an execute
+  error OnlyGovernor();
+
+  /// @notice Thrown when trying to execute an action that only the pending governor an execute
+  error OnlyPendingGovernor();
+
+  /**
+   * @notice Emitted when a new pending governor is set
+   * @param newPendingGovernor The new pending governor
+   */
+  event PendingGovernorSet(address newPendingGovernor);
+
+  /**
+   * @notice Emitted when the pending governor accepts the role and becomes the governor
+   */
+  event PendingGovernorAccepted();
+
+  /**
+   * @notice Returns the address of the governor
+   * @return The address of the governor
+   */
+  function governor() external view returns (address);
+
+  /**
+   * @notice Returns the address of the pending governor
+   * @return The address of the pending governor
+   */
+  function pendingGovernor() external view returns (address);
+
+  /**
+   * @notice Returns whether the given account is the current governor
+   * @param account The account to check
+   * @return Whether it is the current governor or not
+   */
+  function isGovernor(address account) external view returns (bool);
+
+  /**
+   * @notice Returns whether the given account is the pending governor
+   * @param account The account to check
+   * @return Whether it is the pending governor or not
+   */
+  function isPendingGovernor(address account) external view returns (bool);
+
+  /**
+   * @notice Sets a new pending governor
+   * @dev Only the current governor can execute this action
+   * @param pendingGovernor The new pending governor
+   */
+  function setPendingGovernor(address pendingGovernor) external;
+
+  /**
+   * @notice Sets the pending governor as the governor
+   * @dev Only the pending governor can execute this action
+   */
+  function acceptPendingGovernor() external;
+}

--- a/contracts/libraries/PermissionMath.sol
+++ b/contracts/libraries/PermissionMath.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../interfaces/IDCAStrategies.sol';
+
+/// @title Permission Math library
+/// @notice Provides functions to easily convert from permissions to an int representation and viceversa
+library PermissionMath {
+  /// @notice Takes a list of permissions and returns the int representation of the set that contains them all
+  /// @param _permissions The list of permissions
+  /// @return _representation The uint representation
+  function toUInt8(IDCAStrategies.Permission[] memory _permissions) internal pure returns (uint8 _representation) {
+    for (uint256 i; i < _permissions.length; i++) {
+      _representation |= uint8(1 << uint8(_permissions[i]));
+    }
+  }
+
+  /// @notice Takes an int representation of a set of permissions, and returns whether it contains the given permission
+  /// @param _representation The int representation
+  /// @param _permission The permission to check for
+  /// @return _hasPermission Whether the representation contains the given permission
+  function hasPermission(uint8 _representation, IDCAStrategies.Permission _permission) internal pure returns (bool _hasPermission) {
+    uint256 _bitMask = 1 << uint8(_permission);
+    _hasPermission = (_representation & _bitMask) != 0;
+  }
+}

--- a/contracts/utils/Governable.sol
+++ b/contracts/utils/Governable.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../interfaces/utils/IGovernable.sol';
+
+/**
+ * @notice This contract is meant to be used in other contracts. By using this contract,
+ *         a specific address will be given a "governor" role, which basically will be able to
+ *         control certains aspects of the contract. There are other contracts that do the same,
+ *         but this contract forces a new governor to accept the role before it's transferred.
+ *         This is a basically a safety measure to prevent losing access to the contract.
+ */
+abstract contract Governable is IGovernable {
+  /// @inheritdoc IGovernable
+  address public governor;
+
+  /// @inheritdoc IGovernable
+  address public pendingGovernor;
+
+  constructor(address _governor) {
+    if (_governor == address(0)) revert GovernorIsZeroAddress();
+    governor = _governor;
+  }
+
+  /// @inheritdoc IGovernable
+  function isGovernor(address _account) public view returns (bool) {
+    return _account == governor;
+  }
+
+  /// @inheritdoc IGovernable
+  function isPendingGovernor(address _account) public view returns (bool) {
+    return _account == pendingGovernor;
+  }
+
+  /// @inheritdoc IGovernable
+  function setPendingGovernor(address _pendingGovernor) external onlyGovernor {
+    pendingGovernor = _pendingGovernor;
+    emit PendingGovernorSet(_pendingGovernor);
+  }
+
+  /// @inheritdoc IGovernable
+  function acceptPendingGovernor() external onlyPendingGovernor {
+    governor = pendingGovernor;
+    pendingGovernor = address(0);
+    emit PendingGovernorAccepted();
+  }
+
+  modifier onlyGovernor() {
+    if (!isGovernor(msg.sender)) revert OnlyGovernor();
+    _;
+  }
+
+  modifier onlyPendingGovernor() {
+    if (!isPendingGovernor(msg.sender)) revert OnlyPendingGovernor();
+    _;
+  }
+}


### PR DESCRIPTION
- add governable
- add permission math library
- add internal functions
- add code to external functions

I need help on [this](https://github.com/Mean-Finance/dca-v2-periphery/blob/feat/permissions-functions/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPermissionsHandler.sol#L57) and [this](https://github.com/Mean-Finance/dca-v2-periphery/blob/feat/permissions-functions/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPermissionsHandler.sol#L160), also I'm not sure about the name of [this function](https://github.com/Mean-Finance/dca-v2-periphery/blob/feat/permissions-functions/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPermissionsHandler.sol#L173). I tought about rename __mint_ and __burn_ to __create_ and __destroy_