### PR TITLE
feat: user-position

### DIFF
--- a/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPositionsHandler.sol
+++ b/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPositionsHandler.sol
@@ -10,6 +10,11 @@ abstract contract DCAStrategiesPositionsHandler is IDCAStrategiesPositionsHandle
   mapping(uint256 => Position) internal _userPositions;
 
   /// @inheritdoc IDCAStrategiesPositionsHandler
+  function userPosition(uint256 _positionId) external view returns (Position memory _position) {
+    return _userPositions[_positionId];
+  }
+
+  /// @inheritdoc IDCAStrategiesPositionsHandler
   function deposit(IDCAStrategies.DepositParams calldata _parameters) external returns (uint256) {
     // get tokens data
     IDCAStrategies.ShareOfToken[] memory _tokens = _getTokenShares(_parameters.strategyId, _parameters.version);
@@ -47,11 +52,6 @@ abstract contract DCAStrategiesPositionsHandler is IDCAStrategiesPositionsHandle
     );
 
     return _positionId;
-  }
-
-  /// @inheritdoc IDCAStrategiesPositionsHandler
-  function userPosition(uint256 _positionId) external view returns (Position memory _position) {
-    return _userPositions[_positionId];
   }
 
   /// @inheritdoc IDCAStrategiesPositionsHandler
@@ -119,11 +119,11 @@ abstract contract DCAStrategiesPositionsHandler is IDCAStrategiesPositionsHandle
 
   function _depositLoop(IDCAStrategies.DepositParams calldata _parameters, IDCAStrategies.ShareOfToken[] memory _tokens)
     internal
-    returns (uint256[] memory)
+    returns (uint256[] memory _positions)
   {
     uint16 _total = _getTotalShares();
     uint256 _amountSpent;
-    uint256[] memory _positions = new uint256[](_tokens.length);
+    _positions = new uint256[](_tokens.length);
 
     for (uint256 i = 0; i < _tokens.length; ) {
       IDCAStrategies.ShareOfToken memory _token = _tokens[i];
@@ -146,7 +146,5 @@ abstract contract DCAStrategiesPositionsHandler is IDCAStrategiesPositionsHandle
         i++;
       }
     }
-
-    return _positions;
   }
 }

--- a/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPositionsHandler.sol
+++ b/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPositionsHandler.sol
@@ -48,7 +48,8 @@ abstract contract DCAStrategiesPositionsHandler is IDCAStrategiesPositionsHandle
       _parameters.strategyId,
       _parameters.version,
       _parameters.swapInterval,
-      _parameters.permissions
+      _parameters.permissions,
+      _positions
     );
 
     return _positionId;

--- a/contracts/interfaces/IDCAStrategies.sol
+++ b/contracts/interfaces/IDCAStrategies.sol
@@ -383,6 +383,7 @@ interface IDCAStrategiesPositionsHandler {
    * @param version The version number of the strategy selected
    * @param swapInterval How frequently the position's swaps should be executed
    * @param permissions The permissions defined for the position
+   * @param positions An array containing all underlying positions
    */
   event Deposited(
     address indexed depositor,
@@ -392,7 +393,8 @@ interface IDCAStrategiesPositionsHandler {
     uint80 strategyId,
     uint16 version,
     uint32 swapInterval,
-    IDCAStrategies.PermissionSet[] permissions
+    IDCAStrategies.PermissionSet[] permissions,
+    uint256[] positions
   );
 
   /// @notice Thrown when a pair of strategy id and version are non-existing

--- a/contracts/interfaces/IDCAStrategies.sol
+++ b/contracts/interfaces/IDCAStrategies.sol
@@ -417,6 +417,13 @@ interface IDCAStrategiesPositionsHandler {
     uint256[] positions;
   }
 
+  /**
+   * @notice Returns a user position
+   * @param positionId The id of the position
+   * @return position The position itself
+   */
+  function userPosition(uint256 positionId) external view returns (Position memory position);
+
   function deposit(DepositParams calldata parameters) external returns (uint256);
 
   function withdrawSwapped(uint256 positionId, address recipient) external returns (uint256);

--- a/test/unit/DCAStrategies/dca-strategies-positions-handler.spec.ts
+++ b/test/unit/DCAStrategies/dca-strategies-positions-handler.spec.ts
@@ -101,6 +101,7 @@ contract('DCAStrategiesPositionsHandler', () => {
     let amountOfSwaps = 5;
     let swapInterval = 7 * 24 * 60 * 60; // 1 week
     let permissions: any[] = [];
+    let expectedPositionsIds = [BigNumber.from(1), BigNumber.from(2)];
 
     when('invalid strategy and version provided', () => {
       then('tx reverts with message', async () => {
@@ -185,7 +186,6 @@ contract('DCAStrategiesPositionsHandler', () => {
         expect(userPosition.strategyId).to.be.equal(1);
         expect(userPosition.strategyVersion).to.be.equal(1);
 
-        let expectedPositionsIds = [BigNumber.from(1), BigNumber.from(2)];
         expect(userPosition.positions.length).to.be.equal(expectedPositionsIds.length);
         userPosition.positions.forEach((p, i) => {
           expect(p).to.be.equal(expectedPositionsIds[i]);
@@ -194,7 +194,7 @@ contract('DCAStrategiesPositionsHandler', () => {
       then('event is emitted', async () => {
         await expect(tx)
           .to.emit(DCAStrategiesPositionsHandlerMock, 'Deposited')
-          .withArgs(user.address, user.address, 1, tokenA.address, 1, 1, swapInterval, []);
+          .withArgs(user.address, user.address, 1, tokenA.address, 1, 1, swapInterval, [], expectedPositionsIds);
       });
     });
   });

--- a/test/unit/DCAStrategies/dca-strategies-positions-handler.spec.ts
+++ b/test/unit/DCAStrategies/dca-strategies-positions-handler.spec.ts
@@ -186,6 +186,7 @@ contract('DCAStrategiesPositionsHandler', () => {
         expect(userPosition.strategyVersion).to.be.equal(1);
 
         let expectedPositionsIds = [BigNumber.from(1), BigNumber.from(2)];
+        expect(userPosition.positions.length).to.be.equal(expectedPositionsIds.length);
         userPosition.positions.forEach((p, i) => {
           expect(p).to.be.equal(expectedPositionsIds[i]);
         });


### PR DESCRIPTION
- add code to save user position
- tests

I had to make this [mapping](https://github.com/Mean-Finance/dca-v2-periphery/blob/feat/user-position/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPositionsHandler.sol#L10) internal and expose a function to returns its value because of a strange error when overriding a mapping that returns a struct.
Also, I moved the loop logic to an [internal function](https://github.com/Mean-Finance/dca-v2-periphery/blob/feat/user-position/contracts/DCAStrategies/DCAStrategies/DCAStrategiesPositionsHandler.sol#L120) because of `stack to deep error`.