### PR TITLE
refactor: delete legacy functions

### DIFF
--- a/contracts/interfaces/IDCAHubSwapper.sol
+++ b/contracts/interfaces/IDCAHubSwapper.sol
@@ -56,26 +56,6 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
     uint256 deadline;
   }
 
-  /// @notice Parameters to execute a swap with dexes
-  struct LegacySwapWithDexesParams {
-    // The address of the DCAHub
-    ILegacyDCAHub hub;
-    // The tokens involved in the swap
-    address[] tokens;
-    // The pairs to swap
-    IDCAHub.PairIndexes[] pairsToSwap;
-    // The accounts that should be approved for spending
-    Allowance[] allowanceTargets;
-    // The different swappers involved in the swap
-    address[] swappers;
-    // The different swaps to execute
-    SwapExecution[] executions;
-    // Address that will receive all unspent tokens
-    address leftoverRecipient;
-    // Deadline when the swap becomes invalid
-    uint256 deadline;
-  }
-
   /// @notice Parameters to execute a swap for caller
   struct SwapForCallerParams {
     // The address of the DCAHub
@@ -86,24 +66,6 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
     IDCAHub.PairIndexes[] pairsToSwap;
     // Bytes to send to the oracle when executing a quote
     bytes oracleData;
-    // The minimum amount of tokens to receive as part of the swap
-    uint256[] minimumOutput;
-    // The maximum amount of tokens to provide as part of the swap
-    uint256[] maximumInput;
-    // Address that will receive all the tokens from the swap
-    address recipient;
-    // Deadline when the swap becomes invalid
-    uint256 deadline;
-  }
-
-  /// @notice Parameters to execute a swap for caller
-  struct LegacySwapForCallerParams {
-    // The address of the DCAHub
-    ILegacyDCAHub hub;
-    // The tokens involved in the swap
-    address[] tokens;
-    // The pairs to swap
-    IDCAHub.PairIndexes[] pairsToSwap;
     // The minimum amount of tokens to receive as part of the swap
     uint256[] minimumOutput;
     // The maximum amount of tokens to provide as part of the swap
@@ -134,28 +96,11 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
   function swapForCaller(SwapForCallerParams calldata parameters) external payable returns (IDCAHub.SwapInfo memory);
 
   /**
-   * @notice Executes a swap for the caller, by sending them the reward, and taking from them the needed tokens
-   * @dev Can only be called by user with appropriate role
-   *      Will revert:
-   *      - With RewardNotEnough if the minimum output is not met
-   *      - With ToProvideIsTooMuch if the hub swap requires more than the given maximum input
-   * @return The information about the executed swap
-   */
-  function legacySwapForCaller(LegacySwapForCallerParams calldata parameters) external payable returns (ILegacyDCAHub.SwapInfo memory);
-
-  /**
    * @notice Executes a swap with the given swappers, and sends all unspent tokens to the given recipient
    * @dev Can only be called by user with appropriate role
    * @return The information about the executed swap
    */
   function swapWithDexes(SwapWithDexesParams calldata parameters) external payable returns (IDCAHub.SwapInfo memory);
-
-  /**
-   * @notice Executes a swap with the given swappers, and sends all unspent tokens to the given recipient
-   * @dev Can only be called by user with appropriate role
-   * @return The information about the executed swap
-   */
-  function legacySwapWithDexes(LegacySwapWithDexesParams calldata parameters) external payable returns (ILegacyDCAHub.SwapInfo memory);
 
   /**
    * @notice Meant to be used by Mean Finance keepers, as an cheaper way to execute swaps. This function executes a
@@ -166,16 +111,6 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
    * @return The information about the executed swap
    */
   function swapWithDexesForMean(SwapWithDexesParams calldata parameters) external payable returns (IDCAHub.SwapInfo memory);
-
-  /**
-   * @notice Meant to be used by Mean Finance keepers, as an cheaper way to execute swaps. This function executes a
-   *         swap with the given swappers, but sends some of the unspent tokens back to the hub. This means that they
-   *         will be considered part of the protocol's balance. Unspent tokens that were given as reward will be
-   *         sent to the provided recipient
-   * @dev Can only be called by user with appropriate role
-   * @return The information about the executed swap
-   */
-  function legacySwapWithDexesForMean(LegacySwapWithDexesParams calldata parameters) external payable returns (ILegacyDCAHub.SwapInfo memory);
 
   /**
    * @notice Executes an optimized swap, by providing parameters already encoded

--- a/contracts/mocks/LegacyDCASwapper.sol
+++ b/contracts/mocks/LegacyDCASwapper.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import '../interfaces/ILegacyDCAHub.sol';
+
+contract LegacyDCASwapper {
+  using SafeERC20 for IERC20;
+  address internal _swapExecutor;
+
+  function swapForCaller(
+    ILegacyDCAHub _hub,
+    address[] calldata _tokens,
+    IDCAHub.PairIndexes[] calldata _pairsToSwap,
+    address _recipient
+  ) external {
+    // Set the executor
+    _swapExecutor = msg.sender;
+
+    // Execute swap
+    _hub.swap(_tokens, _pairsToSwap, _recipient, address(this), new uint256[](_tokens.length), '');
+
+    // Clear the swap executor
+    _swapExecutor = address(0);
+  }
+
+  // solhint-disable-next-line func-name-mixedcase
+  function DCAHubSwapCall(
+    address,
+    IDCAHub.TokenInSwap[] calldata _tokens,
+    uint256[] calldata,
+    bytes calldata
+  ) external {
+    address _swapExecutorMem = _swapExecutor;
+    for (uint256 i = 0; i < _tokens.length; ) {
+      IDCAHub.TokenInSwap memory _token = _tokens[i];
+      if (_token.toProvide > 0) {
+        // We assume that msg.sender is the DCAHub
+        IERC20(_token.token).safeTransferFrom(_swapExecutorMem, msg.sender, _token.toProvide);
+      }
+      unchecked {
+        i++;
+      }
+    }
+  }
+
+  function _handleSwapForCallerCallback(IDCAHub.TokenInSwap[] calldata _tokens) internal {
+    // Load to mem to avoid reading storage multiple times
+    address _swapExecutorMem = _swapExecutor;
+    for (uint256 i = 0; i < _tokens.length; ) {
+      IDCAHub.TokenInSwap memory _token = _tokens[i];
+      if (_token.toProvide > 0) {
+        // We assume that msg.sender is the DCAHub
+        IERC20(_token.token).safeTransferFrom(_swapExecutorMem, msg.sender, _token.toProvide);
+      }
+      unchecked {
+        i++;
+      }
+    }
+  }
+}

--- a/test/integration/DCAHubCompanion/position-migrator.spec.ts
+++ b/test/integration/DCAHubCompanion/position-migrator.spec.ts
@@ -4,7 +4,7 @@ import { TransactionResponse } from '@ethersproject/providers';
 import { constants, wallet } from '@test-utils';
 import { given, then, when } from '@test-utils/bdd';
 import evm, { snapshot } from '@test-utils/evm';
-import { IERC20, DCAHubCompanion, DCAHubSwapper, LegacyDCASwapper, LegacyDCASwapper__factory } from '@typechained';
+import { IERC20, DCAHubCompanion, LegacyDCASwapper, LegacyDCASwapper__factory } from '@typechained';
 import { DCAHub } from '@mean-finance/dca-v2-core';
 import { StatefulChainlinkOracle } from '@mean-finance/oracles';
 import { ChainlinkRegistry } from '@mean-finance/chainlink-registry';
@@ -34,7 +34,7 @@ describe('Position Migration', () => {
   let WETH: IERC20, USDC: IERC20;
   let positionOwner: SignerWithAddress, swapper: SignerWithAddress;
   let vulnDCAHub: DCAHub, betaDCAHub: DCAHub, yieldlessDCAHub: DCAHub, DCAHub: DCAHub;
-  let DCAHubCompanion: DCAHubCompanion, DCAHubSwapper: DCAHubSwapper, legacyDCAHubSwapper: LegacyDCASwapper;
+  let DCAHubCompanion: DCAHubCompanion, legacyDCAHubSwapper: LegacyDCASwapper;
   let snapshotId: string;
   let chainId: BigNumber;
 
@@ -56,7 +56,6 @@ describe('Position Migration', () => {
 
     DCAHub = await ethers.getContract('DCAHub');
     DCAHubCompanion = await ethers.getContract('DCAHubCompanion');
-    DCAHubSwapper = await ethers.getContract('DCAHubSwapper');
     betaDCAHub = await ethers.getContractAt(DCA_HUB_ABI, BETA_HUB);
     vulnDCAHub = await ethers.getContractAt(DCA_HUB_ABI, VULN_HUB);
     yieldlessDCAHub = await ethers.getContractAt(DCA_HUB_ABI, YIELDLESS_HUB);

--- a/test/unit/DCAHubSwapper/dca-hub-swapper.spec.ts
+++ b/test/unit/DCAHubSwapper/dca-hub-swapper.spec.ts
@@ -4,7 +4,7 @@ import { behaviours, constants, wallet } from '@test-utils';
 import { contract, given, then, when } from '@test-utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { snapshot } from '@test-utils/evm';
-import { DCAHubSwapperMock, DCAHubSwapperMock__factory, IDCAHub, IERC20, ILegacyDCAHub, ISwapper, ISwapperRegistry } from '@typechained';
+import { DCAHubSwapperMock, DCAHubSwapperMock__factory, IDCAHub, IERC20, ISwapper, ISwapperRegistry } from '@typechained';
 import { FakeContract, smock } from '@defi-wonderland/smock';
 import { BigNumberish } from '@ethersproject/bignumber';
 import { BytesLike } from '@ethersproject/bytes';
@@ -19,7 +19,6 @@ contract('DCAHubSwapper', () => {
   const DEX = constants.NOT_ZERO_ADDRESS;
   let swapExecutioner: SignerWithAddress, recipient: SignerWithAddress, admin: SignerWithAddress, superAdmin: SignerWithAddress;
   let DCAHub: FakeContract<IDCAHub>;
-  let legacyDCAHub: FakeContract<ILegacyDCAHub>;
   let DCAHubSwapperFactory: DCAHubSwapperMock__factory;
   let DCAHubSwapper: DCAHubSwapperMock;
   let swapperRegistry: FakeContract<ISwapperRegistry>;
@@ -34,7 +33,6 @@ contract('DCAHubSwapper', () => {
     [, swapExecutioner, admin, recipient, superAdmin] = await ethers.getSigners();
     DCAHubSwapperFactory = await ethers.getContractFactory('contracts/mocks/DCAHubSwapper/DCAHubSwapper.sol:DCAHubSwapperMock');
     DCAHub = await smock.fake('IDCAHub');
-    legacyDCAHub = await smock.fake('ILegacyDCAHub');
     swapperRegistry = await smock.fake('ISwapperRegistry');
     DCAHubSwapper = await DCAHubSwapperFactory.deploy(swapperRegistry.address, superAdmin.address, [admin.address], [swapExecutioner.address]);
     tokenA = await smock.fake('IERC20');
@@ -49,7 +47,6 @@ contract('DCAHubSwapper', () => {
   beforeEach('Deploy and configure', async () => {
     await snapshot.revert(snapshotId);
     DCAHub.swap.reset();
-    legacyDCAHub.swap.reset();
     swapperRegistry.isSwapperAllowlisted.reset();
     swapperRegistry.isSwapperAllowlisted.returns(true);
     swapperRegistry.isValidAllowanceTarget.returns(true);
@@ -241,143 +238,6 @@ contract('DCAHubSwapper', () => {
       role: () => swapExecutionRole,
     });
   });
-  describe('legacySwapForCaller', () => {
-    const SOME_RANDOM_ADDRESS = wallet.generateRandomAddress();
-    whenDeadlineHasExpiredThenTxReverts({
-      func: 'legacySwapForCaller',
-      args: () => [
-        {
-          hub: legacyDCAHub.address,
-          tokens,
-          pairsToSwap: INDEXES,
-          minimumOutput: [],
-          maximumInput: [],
-          recipient: SOME_RANDOM_ADDRESS,
-          deadline: 0,
-        },
-      ],
-    });
-    when('hub returns less than minimum output', () => {
-      const MIN_OUTPUT = 200000;
-      const MAX_INPUT = constants.MAX_UINT_256;
-      given(() => {
-        legacyDCAHub.swap.returns({
-          tokens: [
-            {
-              token: tokenA.address,
-              reward: MIN_OUTPUT - 1,
-              toProvide: MAX_INPUT,
-              platformFee: 0,
-            },
-            {
-              token: tokenB.address,
-              reward: MIN_OUTPUT - 1,
-              toProvide: MAX_INPUT,
-              platformFee: 0,
-            },
-          ],
-          pairs: [],
-        });
-      });
-      then('reverts with message', async () => {
-        await behaviours.txShouldRevertWithMessage({
-          contract: DCAHubSwapper.connect(swapExecutioner),
-          func: 'legacySwapForCaller',
-          args: [
-            {
-              hub: legacyDCAHub.address,
-              tokens,
-              pairsToSwap: INDEXES,
-              minimumOutput: [MIN_OUTPUT, MIN_OUTPUT],
-              maximumInput: [MAX_INPUT, MAX_INPUT],
-              recipient: SOME_RANDOM_ADDRESS,
-              deadline: constants.MAX_UINT_256,
-            },
-          ],
-          message: 'RewardNotEnough',
-        });
-      });
-    });
-    when('hub asks for more than maximum input', () => {
-      const MIN_OUTPUT = 200000;
-      const MAX_INPUT = 5000000;
-      given(() => {
-        legacyDCAHub.swap.returns({
-          tokens: [
-            {
-              token: tokenA.address,
-              reward: MIN_OUTPUT,
-              toProvide: MAX_INPUT + 1,
-              platformFee: 0,
-            },
-            {
-              token: tokenB.address,
-              reward: MIN_OUTPUT,
-              toProvide: MAX_INPUT + 1,
-              platformFee: 0,
-            },
-          ],
-          pairs: [],
-        });
-      });
-      then('reverts with message', async () => {
-        await behaviours.txShouldRevertWithMessage({
-          contract: DCAHubSwapper.connect(swapExecutioner),
-          func: 'legacySwapForCaller',
-          args: [
-            {
-              hub: legacyDCAHub.address,
-              tokens,
-              pairsToSwap: INDEXES,
-              minimumOutput: [MIN_OUTPUT, MIN_OUTPUT],
-              maximumInput: [MAX_INPUT, MAX_INPUT],
-              recipient: SOME_RANDOM_ADDRESS,
-              deadline: constants.MAX_UINT_256,
-            },
-          ],
-          message: 'ToProvideIsTooMuch',
-        });
-      });
-    });
-    when('swap is executed', () => {
-      given(async () => {
-        await DCAHubSwapper.connect(swapExecutioner).legacySwapForCaller({
-          hub: legacyDCAHub.address,
-          tokens,
-          pairsToSwap: INDEXES,
-          minimumOutput: [],
-          maximumInput: [],
-          recipient: SOME_RANDOM_ADDRESS,
-          deadline: constants.MAX_UINT_256,
-        });
-      });
-      thenLegacyHubIsCalledWith({
-        rewardRecipient: SOME_RANDOM_ADDRESS,
-        callbackData: () => encode({ plan: 'swap for caller', bytes: 'none' }),
-      });
-      then('swap executor is cleared', async () => {
-        expect(await DCAHubSwapper.isSwapExecutorEmpty()).to.be.true;
-      });
-    });
-    behaviours.shouldBeExecutableOnlyByRole({
-      contract: () => DCAHubSwapper,
-      funcAndSignature: 'legacySwapForCaller',
-      params: () => [
-        {
-          hub: legacyDCAHub.address,
-          tokens,
-          pairsToSwap: INDEXES,
-          oracleData: BYTES,
-          minimumOutput: [0, 0],
-          maximumInput: [constants.MAX_UINT_256, constants.MAX_UINT_256],
-          recipient: SOME_RANDOM_ADDRESS,
-          deadline: constants.MAX_UINT_256,
-        },
-      ],
-      addressWithRole: () => swapExecutioner,
-      role: () => swapExecutionRole,
-    });
-  });
   describe('swapWithDexes', () => {
     whenDeadlineHasExpiredThenTxReverts({
       func: 'swapWithDexes',
@@ -452,76 +312,6 @@ contract('DCAHubSwapper', () => {
       role: () => swapExecutionRole,
     });
   });
-  describe('legacySwapWithDexes', () => {
-    whenDeadlineHasExpiredThenTxReverts({
-      func: 'legacySwapWithDexes',
-      args: () => [
-        {
-          hub: legacyDCAHub.address,
-          tokens: [],
-          pairsToSwap: [],
-          allowanceTargets: [],
-          swappers: [],
-          executions: [],
-          leftoverRecipient: recipient.address,
-          deadline: 0,
-        },
-      ],
-    });
-    when('executing a swap with dexes', () => {
-      given(async () => {
-        await DCAHubSwapper.connect(swapExecutioner).legacySwapWithDexes({
-          hub: legacyDCAHub.address,
-          tokens: tokens,
-          pairsToSwap: INDEXES,
-          allowanceTargets: [{ token: tokenA.address, allowanceTarget: DEX, minAllowance: 2000 }],
-          swappers: [DEX],
-          executions: [{ swapData: BYTES, swapperIndex: 0 }],
-          leftoverRecipient: recipient.address,
-          deadline: constants.MAX_UINT_256,
-        });
-      });
-      then('allowance was called correctly', async () => {
-        const calls = await DCAHubSwapper.maxApproveSpenderCalls();
-        expect(calls).to.have.lengthOf(1);
-        expect(calls[0].token).to.equal(tokenA.address);
-        expect(calls[0].spender).to.equal(DEX);
-        expect(calls[0].minAllowance).to.equal(2000);
-        expect(calls[0].alreadyValidatedSpender).to.be.false;
-      });
-      thenLegacyHubIsCalledWith({
-        rewardRecipient: () => DCAHubSwapper,
-        callbackData: () =>
-          encode({
-            plan: 'dexes',
-            bytes: {
-              swappers: [DEX],
-              executions: [{ data: BYTES, index: 0 }],
-              sendToProvideLeftoverToHub: false,
-              leftoverRecipient: recipient,
-            },
-          }),
-      });
-    });
-    behaviours.shouldBeExecutableOnlyByRole({
-      contract: () => DCAHubSwapper,
-      funcAndSignature: 'legacySwapWithDexes',
-      params: () => [
-        {
-          hub: legacyDCAHub.address,
-          tokens: tokens,
-          pairsToSwap: INDEXES,
-          allowanceTargets: [{ token: tokenA.address, allowanceTarget: DEX, minAllowance: 2000 }],
-          swappers: [DEX],
-          executions: [{ swapData: BYTES, swapperIndex: 0 }],
-          leftoverRecipient: recipient.address,
-          deadline: constants.MAX_UINT_256,
-        },
-      ],
-      addressWithRole: () => swapExecutioner,
-      role: () => swapExecutionRole,
-    });
-  });
   describe('swapWithDexesForMean', () => {
     whenDeadlineHasExpiredThenTxReverts({
       func: 'swapWithDexesForMean',
@@ -585,76 +375,6 @@ contract('DCAHubSwapper', () => {
           tokens: tokens,
           pairsToSwap: INDEXES,
           oracleData: BYTES,
-          allowanceTargets: [{ token: tokenA.address, allowanceTarget: DEX, minAllowance: 2000 }],
-          swappers: [DEX],
-          executions: [{ swapData: BYTES, swapperIndex: 0 }],
-          leftoverRecipient: recipient.address,
-          deadline: constants.MAX_UINT_256,
-        },
-      ],
-      addressWithRole: () => swapExecutioner,
-      role: () => swapExecutionRole,
-    });
-  });
-  describe('legacySwapWithDexesForMean', () => {
-    whenDeadlineHasExpiredThenTxReverts({
-      func: 'legacySwapWithDexesForMean',
-      args: () => [
-        {
-          hub: legacyDCAHub.address,
-          tokens: [],
-          pairsToSwap: [],
-          allowanceTargets: [],
-          swappers: [],
-          executions: [],
-          leftoverRecipient: recipient.address,
-          deadline: 0,
-        },
-      ],
-    });
-    when('executing a swap with dexes', () => {
-      given(async () => {
-        await DCAHubSwapper.connect(swapExecutioner).legacySwapWithDexesForMean({
-          hub: legacyDCAHub.address,
-          tokens: tokens,
-          pairsToSwap: INDEXES,
-          allowanceTargets: [{ token: tokenA.address, allowanceTarget: DEX, minAllowance: 2000 }],
-          swappers: [DEX],
-          executions: [{ swapData: BYTES, swapperIndex: 0 }],
-          leftoverRecipient: recipient.address,
-          deadline: constants.MAX_UINT_256,
-        });
-      });
-      then('allowance was called correctly', async () => {
-        const calls = await DCAHubSwapper.maxApproveSpenderCalls();
-        expect(calls).to.have.lengthOf(1);
-        expect(calls[0].token).to.equal(tokenA.address);
-        expect(calls[0].spender).to.equal(DEX);
-        expect(calls[0].minAllowance).to.equal(2000);
-        expect(calls[0].alreadyValidatedSpender).to.be.false;
-      });
-      thenLegacyHubIsCalledWith({
-        rewardRecipient: () => DCAHubSwapper,
-        callbackData: () =>
-          encode({
-            plan: 'dexes',
-            bytes: {
-              swappers: [DEX],
-              executions: [{ data: BYTES, index: 0 }],
-              sendToProvideLeftoverToHub: true,
-              leftoverRecipient: recipient,
-            },
-          }),
-      });
-    });
-    behaviours.shouldBeExecutableOnlyByRole({
-      contract: () => DCAHubSwapper,
-      funcAndSignature: 'legacySwapWithDexesForMean',
-      params: () => [
-        {
-          hub: legacyDCAHub.address,
-          tokens: tokens,
-          pairsToSwap: INDEXES,
           allowanceTargets: [{ token: tokenA.address, allowanceTarget: DEX, minAllowance: 2000 }],
           swappers: [DEX],
           executions: [{ swapData: BYTES, swapperIndex: 0 }],
@@ -955,28 +675,6 @@ contract('DCAHubSwapper', () => {
           message: 'Transaction too old',
         });
       });
-    });
-  }
-  function thenLegacyHubIsCalledWith({
-    callbackData: expectedCalbackData,
-    rewardRecipient: expectedRewardRecipient,
-  }: {
-    rewardRecipient: string | (() => { address: string });
-    callbackData: () => BytesLike;
-  }) {
-    then('legacy hub was called with the correct parameters', () => {
-      expect(legacyDCAHub.swap).to.have.been.calledOnce;
-      const [tokensInHub, indexes, rewardRecipient, callbackHandler, borrow, callbackData] = legacyDCAHub.swap.getCall(0).args;
-      expect(tokensInHub).to.eql(tokens);
-      expect((indexes as any)[0]).to.eql([0, 1]);
-      expect(rewardRecipient).to.equal(
-        typeof expectedRewardRecipient === 'string' ? expectedRewardRecipient : expectedRewardRecipient().address
-      );
-      expect(callbackHandler).to.equal(DCAHubSwapper.address);
-      expect(borrow).to.have.lengthOf(2);
-      expect((borrow as any)[0]).to.equal(constants.ZERO);
-      expect((borrow as any)[1]).to.equal(constants.ZERO);
-      expect(callbackData).to.equal(expectedCalbackData());
     });
   }
   function thenHubIsCalledWith({


### PR DESCRIPTION
We are now deleting `legacySwapForCaller`, `legacySwapWithDexes` and `legacySwapWithDexesForMean`. We decided that if we want to interact with the legacy Hubs, we will use the old DCA Swapper