### PR TITLE
feat: add intermediate tokens

### DIFF
--- a/contracts/DCAHubSwapper/DCAHubSwapper.sol
+++ b/contracts/DCAHubSwapper/DCAHubSwapper.sol
@@ -26,6 +26,8 @@ contract DCAHubSwapper is DeadlineValidation, AccessControl, GetBalances, IDCAHu
     address[] swappers;
     // The different swaps to execute
     SwapExecution[] executions;
+    // A list of tokens to check for unspent balance
+    address[] intermediateTokensToCheck;
     // The address that will receive the unspent tokens
     address leftoverRecipient;
     // This flag is just a way to make transactions cheaper. If Mean Finance is executing the swap, then it's the same for us
@@ -175,7 +177,8 @@ contract DCAHubSwapper is DeadlineValidation, AccessControl, GetBalances, IDCAHu
       swappers: _parameters.swappers,
       executions: _parameters.executions,
       leftoverRecipient: _parameters.leftoverRecipient,
-      sendToProvideLeftoverToHub: _sendToProvideLeftoverToHub
+      sendToProvideLeftoverToHub: _sendToProvideLeftoverToHub,
+      intermediateTokensToCheck: _parameters.intermediateTokensToCheck
     });
 
     // Execute swap
@@ -251,6 +254,14 @@ contract DCAHubSwapper is DeadlineValidation, AccessControl, GetBalances, IDCAHu
           _token.safeTransfer(_callbackData.leftoverRecipient, _balance);
         }
       }
+      unchecked {
+        i++;
+      }
+    }
+
+    // Check intermediate tokens
+    for (uint256 i = 0; i < _callbackData.intermediateTokensToCheck.length; ) {
+      _sendBalanceOnContractToRecipient(_callbackData.intermediateTokensToCheck[i], _callbackData.leftoverRecipient);
       unchecked {
         i++;
       }

--- a/contracts/interfaces/IDCAHubSwapper.sol
+++ b/contracts/interfaces/IDCAHubSwapper.sol
@@ -26,6 +26,9 @@ interface IDCAHubSwapper is IDCAHubSwapCallee {
     SwapExecution[] executions;
     // Address that will receive all unspent tokens
     address leftoverRecipient;
+    // A list of tokens to check for unspent balance. These should be tokens that were
+    // not `toProvide` nor `reward` tokens
+    address[] intermediateTokensToCheck;
     // Deadline when the swap becomes invalid
     uint256 deadline;
   }

--- a/contracts/mocks/DCAHubSwapper/DCAHubSwapper.sol
+++ b/contracts/mocks/DCAHubSwapper/DCAHubSwapper.sol
@@ -17,8 +17,14 @@ contract DCAHubSwapperMock is DCAHubSwapper {
     address recipient;
   }
 
+  struct SendBalanceOnContractToRecipientCall {
+    address token;
+    address recipient;
+  }
+
   MaxApproveSpenderCall[] internal _maxApproveSpenderCalls;
   SendToRecipientCall[] internal _sendToRecipientCalls;
+  SendBalanceOnContractToRecipientCall[] internal _sendBalanceOnContractToRecipientCalls;
   RevokeAction[][] internal _revokeCalls;
 
   constructor(
@@ -30,6 +36,10 @@ contract DCAHubSwapperMock is DCAHubSwapper {
 
   function maxApproveSpenderCalls() external view returns (MaxApproveSpenderCall[] memory) {
     return _maxApproveSpenderCalls;
+  }
+
+  function sendBalanceOnContractToRecipientCalls() external view returns (SendBalanceOnContractToRecipientCall[] memory) {
+    return _sendBalanceOnContractToRecipientCalls;
   }
 
   function sendToRecipientCalls() external view returns (SendToRecipientCall[] memory) {
@@ -66,6 +76,11 @@ contract DCAHubSwapperMock is DCAHubSwapper {
   ) internal override {
     _sendToRecipientCalls.push(SendToRecipientCall(_token, _amount, _recipient));
     super._sendToRecipient(_token, _amount, _recipient);
+  }
+
+  function _sendBalanceOnContractToRecipient(address _token, address _recipient) internal override {
+    _sendBalanceOnContractToRecipientCalls.push(SendBalanceOnContractToRecipientCall(_token, _recipient));
+    super._sendBalanceOnContractToRecipient(_token, _recipient);
   }
 
   function isSwapExecutorEmpty() external view returns (bool) {

--- a/test/integration/DCAHubSwapper/multi-pair-swap-with-dex.spec.ts
+++ b/test/integration/DCAHubSwapper/multi-pair-swap-with-dex.spec.ts
@@ -167,6 +167,7 @@ contract('Multi pair swap with DEX', () => {
             { swapperIndex: 0, swapData: dexQuotes[0].data },
             { swapperIndex: 0, swapData: dexQuotes[1].data },
           ],
+          intermediateTokensToCheck: [],
           leftoverRecipient: recipient.address,
           deadline: constants.MAX_UINT_256,
         });

--- a/test/integration/DCAHubSwapper/optimized-multi-pair-swap-with-dex.spec.ts
+++ b/test/integration/DCAHubSwapper/optimized-multi-pair-swap-with-dex.spec.ts
@@ -293,8 +293,8 @@ contract('Optimized multi pair swap with DEX', () => {
         [
           swap.swappers,
           swap.executions.map(({ index, data }) => [index, data]),
-          swap.leftoverRecipient.address,
           swap.extraTokens,
+          swap.leftoverRecipient.address,
           swap.sendToProvideLeftoverToHub,
         ],
       ]

--- a/test/integration/DCAHubSwapper/optimized-multi-pair-swap-with-dex.spec.ts
+++ b/test/integration/DCAHubSwapper/optimized-multi-pair-swap-with-dex.spec.ts
@@ -160,6 +160,7 @@ contract('Optimized multi pair swap with DEX', () => {
             { index: 0, data: dexQuotes[1].data },
           ],
           leftoverRecipient: recipient,
+          extraTokens: [],
           sendToProvideLeftoverToHub: false,
         });
         const swapTx = await DCAHubSwapper.optimizedSwap({
@@ -281,13 +282,22 @@ contract('Optimized multi pair swap with DEX', () => {
     swappers: string[];
     executions: { data: BytesLike; index: number }[];
     sendToProvideLeftoverToHub: boolean;
+    extraTokens: string[];
     leftoverRecipient: { address: string };
   };
   function encode(swap: SwapWithDexes) {
     const abiCoder = new utils.AbiCoder();
     const swapData = abiCoder.encode(
-      ['tuple(address[], tuple(uint8, bytes)[], address, bool)'],
-      [[swap.swappers, swap.executions.map(({ index, data }) => [index, data]), swap.leftoverRecipient.address, swap.sendToProvideLeftoverToHub]]
+      ['tuple(address[], tuple(uint8, bytes)[], address[], address, bool)'],
+      [
+        [
+          swap.swappers,
+          swap.executions.map(({ index, data }) => [index, data]),
+          swap.leftoverRecipient.address,
+          swap.extraTokens,
+          swap.sendToProvideLeftoverToHub,
+        ],
+      ]
     );
     return abiCoder.encode(['tuple(uint256, bytes)'], [[2, swapData]]);
   }

--- a/test/integration/DCAHubSwapper/single-pair-swap-with-dex.spec.ts
+++ b/test/integration/DCAHubSwapper/single-pair-swap-with-dex.spec.ts
@@ -143,6 +143,7 @@ contract('Single pair swap with DEX', () => {
           swappers: [dexQuote.to],
           executions: [{ swapperIndex: 0, swapData: dexQuote.data }],
           leftoverRecipient: recipient.address,
+          intermediateTokensToCheck: [],
           deadline: constants.MAX_UINT_256,
         });
         ({ reward, toProvide, receivedFromAgg, sentToAgg } = await getTransfers(swapTx));


### PR DESCRIPTION
We realized that in complex swaps (like yield(WETH) => WETH => USDC), we might have intermediate tokens. But we don't have a way to check these tokens for unspent balance. So we are adding this