### PR TITLE
feat: add third party dca swapper

### DIFF
--- a/contracts/DCAHubSwapper/ThirdPartyDCAHubSwapper.sol
+++ b/contracts/DCAHubSwapper/ThirdPartyDCAHubSwapper.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHubSwapCallee.sol';
+
+contract ThirdPartyDCAHubSwapper is IDCAHubSwapCallee {
+  /// @notice A target we want to give allowance to
+  struct Allowance {
+    IERC20 token;
+    address spender;
+    uint256 amount;
+  }
+
+  /// @notice The data necessary for a swap to be executed
+  struct SwapExecution {
+    address swapper;
+    bytes swapData;
+  }
+
+  /// @notice Data used for the callback
+  struct SwapWithDexesCallbackData {
+    // Timestamp where the tx is no longer valid
+    uint256 deadline;
+    // Targets to set allowance to
+    Allowance[] allowanceTargets;
+    // The different swaps to execute
+    SwapExecution[] executions;
+    // A list of tokens to check for unspent balance (should not be reward/to provide)
+    IERC20[] intermediateTokensToCheck;
+    // The address that will receive the unspent tokens
+    address leftoverRecipient;
+    // This flag is just a way to make transactions cheaper. If Mean Finance is executing the swap, then it's the same for us
+    // if the leftover tokens go to the hub, or to another address. But, it's cheaper in terms of gas to send them to the hub
+    bool sendToProvideLeftoverToHub;
+  }
+
+  /// @notice Thrown when deadline has passed
+  error TransactionTooOld();
+
+  using SafeERC20 for IERC20;
+  using Address for address;
+
+  // solhint-disable-next-line func-name-mixedcase
+  function DCAHubSwapCall(
+    address,
+    IDCAHub.TokenInSwap[] calldata _tokens,
+    uint256[] calldata,
+    bytes calldata _data
+  ) external {
+    SwapWithDexesCallbackData memory _callbackData = abi.decode(_data, (SwapWithDexesCallbackData));
+    if (block.timestamp > _callbackData.deadline) revert TransactionTooOld();
+    _approveAllowances(_callbackData.allowanceTargets);
+    _executeSwaps(_callbackData.executions);
+    _handleLeftoverTokens(_tokens, _callbackData.leftoverRecipient, _callbackData.sendToProvideLeftoverToHub);
+    _handleIntermediateTokens(_callbackData.intermediateTokensToCheck, _callbackData.leftoverRecipient);
+  }
+
+  function _approveAllowances(Allowance[] memory _allowanceTargets) internal {
+    for (uint256 i = 0; i < _allowanceTargets.length; ) {
+      Allowance memory _target = _allowanceTargets[i];
+      uint256 _currentAllowance = _target.token.allowance(address(this), _target.spender);
+      if (_currentAllowance < _target.amount) {
+        if (_currentAllowance > 0) {
+          _target.token.approve(_target.spender, 0); // We do this because some tokens (like USDT) fail if we don't
+        }
+        _target.token.approve(_target.spender, type(uint256).max);
+      }
+      unchecked {
+        ++i;
+      }
+    }
+  }
+
+  function _executeSwaps(SwapExecution[] memory _executions) internal {
+    for (uint256 i = 0; i < _executions.length; ) {
+      SwapExecution memory _execution = _executions[i];
+      _execution.swapper.functionCall(_execution.swapData, 'Call to swapper failed');
+      unchecked {
+        ++i;
+      }
+    }
+  }
+
+  function _handleLeftoverTokens(
+    IDCAHub.TokenInSwap[] calldata _tokens,
+    address _leftoverRecipient,
+    bool _sendToProvideLeftoverToHub
+  ) internal {
+    for (uint256 i = 0; i < _tokens.length; ) {
+      IERC20 _token = IERC20(_tokens[i].token);
+      uint256 _balance = _token.balanceOf(address(this));
+      if (_balance > 0) {
+        uint256 _toProvide = _tokens[i].toProvide;
+        if (_toProvide > 0) {
+          if (_sendToProvideLeftoverToHub) {
+            // Send everything to hub (we assume the hub is msg.sender)
+            _token.safeTransfer(msg.sender, _balance);
+          } else {
+            // Send necessary to hub (we assume the hub is msg.sender)
+            _token.safeTransfer(msg.sender, _toProvide);
+            if (_balance > _toProvide) {
+              // If there is some left, send to leftover recipient
+              _token.safeTransfer(_leftoverRecipient, _balance - _toProvide);
+            }
+          }
+        } else {
+          // Send reward to the leftover recipient
+          _token.safeTransfer(_leftoverRecipient, _balance);
+        }
+      }
+      unchecked {
+        ++i;
+      }
+    }
+  }
+
+  function _handleIntermediateTokens(IERC20[] memory _intermediateTokens, address _leftoverRecipient) internal {
+    for (uint256 i = 0; i < _intermediateTokens.length; ) {
+      uint256 _balance = _intermediateTokens[i].balanceOf(address(this));
+      if (_balance > 0) {
+        _intermediateTokens[i].safeTransfer(_leftoverRecipient, _balance);
+      }
+      unchecked {
+        ++i;
+      }
+    }
+  }
+}

--- a/test/unit/DCAHubSwapper/third-party-dca-hub-swapper.spec.ts
+++ b/test/unit/DCAHubSwapper/third-party-dca-hub-swapper.spec.ts
@@ -1,0 +1,279 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { behaviours, constants } from '@test-utils';
+import { contract, given, then, when } from '@test-utils/bdd';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { snapshot } from '@test-utils/evm';
+import { IERC20, ISwapper, ThirdPartyDCAHubSwapper, ThirdPartyDCAHubSwapper__factory } from '@typechained';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+import { BigNumberish } from '@ethersproject/bignumber';
+import { BytesLike } from '@ethersproject/bytes';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { utils } from 'ethers';
+
+chai.use(smock.matchers);
+
+contract.only('ThirdPartyDCAHubSwapper', () => {
+  const ABI_CODER = new utils.AbiCoder();
+  let recipient: SignerWithAddress, hub: SignerWithAddress;
+  let DCAHubSwapper: ThirdPartyDCAHubSwapper;
+  let token: FakeContract<IERC20>, intermediateToken: FakeContract<IERC20>;
+  let snapshotId: string;
+
+  before(async () => {
+    [recipient, hub] = await ethers.getSigners();
+    const DCAHubSwapperFactory: ThirdPartyDCAHubSwapper__factory = await ethers.getContractFactory('ThirdPartyDCAHubSwapper');
+    DCAHubSwapper = await DCAHubSwapperFactory.deploy();
+    token = await smock.fake('IERC20');
+    intermediateToken = await smock.fake('IERC20');
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach('Deploy and configure', async () => {
+    await snapshot.revert(snapshotId);
+    token.transfer.reset();
+    token.balanceOf.reset();
+    token.approve.reset();
+    token.allowance.reset();
+    token.transfer.returns(true);
+    token.transferFrom.returns(true);
+    intermediateToken.transfer.reset();
+    intermediateToken.balanceOf.reset();
+    intermediateToken.transfer.returns(true);
+  });
+
+  describe('DCAHubSwapCall', () => {
+    let swapper: FakeContract<ISwapper>;
+    let swapExecution: BytesLike;
+    given(async () => {
+      swapper = await smock.fake('ISwapper');
+      const { data } = await swapper.populateTransaction.swap(token.address, 1000, token.address);
+      swapExecution = data!;
+    });
+
+    describe('deadline', () => {
+      when('deadline has expired', () => {
+        then('reverts with message', async () => {
+          const data = encode({ deadline: 0 });
+          await behaviours.txShouldRevertWithMessage({
+            contract: DCAHubSwapper,
+            func: 'DCAHubSwapCall',
+            args: [constants.ZERO_ADDRESS, [], [], data],
+            message: 'TransactionTooOld',
+          });
+        });
+      });
+    });
+
+    describe('allowances', () => {
+      const ACCOUNT = '0x0000000000000000000000000000000000000010';
+
+      allowanceTest({
+        when: 'current allowance is enough',
+        then: 'approve is not called',
+        allowance: 100,
+        needed: 5,
+        assertion: (token) => expect(token.approve).to.not.have.been.called,
+      });
+
+      allowanceTest({
+        when: 'need approval but current allowance more than zero',
+        then: 'approve is called twice',
+        allowance: 100,
+        needed: 200,
+        assertion: (token) => {
+          expect(token.approve).to.have.been.calledTwice;
+          expect(token.approve).to.have.been.calledWith(ACCOUNT, 0);
+          expect(token.approve).to.have.been.calledWith(ACCOUNT, constants.MAX_UINT_256);
+        },
+      });
+
+      allowanceTest({
+        when: 'need approval and current allowance is zero',
+        then: 'approve is called only once',
+        allowance: 0,
+        needed: 200,
+        assertion: (token) => expect(token.approve).to.have.been.calledOnceWith(ACCOUNT, constants.MAX_UINT_256),
+      });
+
+      function allowanceTest({
+        when: title,
+        then: thenTitle,
+        allowance,
+        needed,
+        assertion,
+      }: {
+        when: string;
+        then: string;
+        allowance: BigNumberish;
+        needed: BigNumberish;
+        assertion: (_: FakeContract<IERC20>) => void;
+      }) {
+        when(title, () => {
+          given(async () => {
+            token.allowance.returns(allowance);
+            const data = encode({ allowanceTargets: [{ token: token.address, spender: ACCOUNT, amount: needed }] });
+            await DCAHubSwapper.connect(hub).DCAHubSwapCall(constants.ZERO_ADDRESS, [], [], data);
+          });
+          then(thenTitle, () => assertion(token));
+          then('allowance is checked correctly', () => {
+            expect(token.allowance).to.have.been.calledOnceWith(DCAHubSwapper.address, ACCOUNT);
+          });
+        });
+      }
+    });
+
+    describe('swaps', () => {
+      when('swapper call fails', () => {
+        let tx: Promise<TransactionResponse>;
+        given(() => {
+          swapper.swap.reverts();
+          const data = encode({ executions: [{ swapper: swapper.address, data: swapExecution }] });
+          tx = DCAHubSwapper.connect(hub).DCAHubSwapCall(constants.ZERO_ADDRESS, [], [], data);
+        });
+        then('then swap reverts', async () => {
+          await expect(tx).to.have.revertedWith('Call to swapper failed');
+        });
+      });
+    });
+
+    describe('leftover tokens', () => {
+      leftoverTokensTest({
+        when: 'balance is zero',
+        then: 'no transfers are executed',
+        balance: 0,
+        assertion: (token) => expect(token.transfer).to.not.have.been.called,
+      });
+
+      leftoverTokensTest({
+        when: 'token needs to be provided and hub flag is set',
+        then: 'everything is transferred to the hub',
+        sendToHubFlag: true,
+        balance: 12345,
+        toProvide: 10000,
+        assertion: (token) => expect(token.transfer).to.have.been.calledOnceWith(hub.address, 12345),
+      });
+
+      leftoverTokensTest({
+        when: 'token needs to be provided but there is no leftover',
+        then: 'available balance is sent to the hub only',
+        sendToHubFlag: false,
+        balance: 12345,
+        toProvide: 12345,
+        assertion: (token) => expect(token.transfer).to.have.been.calledOnceWith(hub.address, 12345),
+      });
+
+      leftoverTokensTest({
+        when: 'token needs to be provided and there is some leftover',
+        then: 'leftover is sent to the recipient',
+        sendToHubFlag: false,
+        balance: 12345,
+        toProvide: 10000,
+        assertion: (token, recipient) => {
+          expect(token.transfer).to.have.been.calledTwice;
+          expect(token.transfer).to.have.been.calledWith(hub.address, 10000);
+          expect(token.transfer).to.have.been.calledWith(recipient, 2345);
+        },
+      });
+
+      leftoverTokensTest({
+        when: 'token is reward (to provide is zero)',
+        then: 'everything is transferred to recipient',
+        balance: 12345,
+        toProvide: 0,
+        assertion: (token, recipient) => expect(token.transfer).to.have.been.calledOnceWith(recipient, 12345),
+      });
+
+      function leftoverTokensTest({
+        when: title,
+        then: thenTitle,
+        balance,
+        toProvide,
+        sendToHubFlag,
+        assertion,
+      }: {
+        when: string;
+        then: string;
+        balance: BigNumberish;
+        toProvide?: BigNumberish;
+        sendToHubFlag?: boolean;
+        assertion: (_: FakeContract<IERC20>, recipient: string) => void;
+      }) {
+        when(title, () => {
+          given(async () => {
+            const tokensInSwap = [{ token: token.address, toProvide: toProvide ?? 0, reward: 0, platformFee: 0 }];
+            token.balanceOf.returns(balance);
+            const data = encode({
+              executions: [{ swapper: swapper.address, data: swapExecution }],
+              sendToProvideLeftoverToHub: sendToHubFlag ?? true,
+            });
+            await DCAHubSwapper.connect(hub).DCAHubSwapCall(constants.ZERO_ADDRESS, tokensInSwap, [], data);
+          });
+          then(thenTitle, () => assertion(token, recipient.address));
+          then('balance is called correctly', () => {
+            expect(token.balanceOf).to.have.been.calledOnceWith(DCAHubSwapper.address);
+          });
+          then('swap is executed correctly', () => {
+            expect(swapper.swap).to.have.been.calledOnceWith(token.address, 1000, token.address);
+          });
+        });
+      }
+    });
+
+    describe('intermediate tokens', () => {
+      let data: BytesLike;
+      given(() => {
+        data = encode({ extraTokens: [intermediateToken.address] });
+      });
+      when('intermediate token has balance', () => {
+        given(async () => {
+          intermediateToken.balanceOf.returns(12345);
+          await DCAHubSwapper.connect(hub).DCAHubSwapCall(constants.ZERO_ADDRESS, [], [], data);
+        });
+        then('balance is called correctly', () => {
+          expect(intermediateToken.balanceOf).to.have.been.calledOnceWith(DCAHubSwapper.address);
+        });
+        then('it is transferred', () => {
+          expect(intermediateToken.transfer).to.have.been.calledOnceWith(recipient.address, 12345);
+        });
+      });
+
+      when('intermediate token has no balance', () => {
+        given(async () => {
+          intermediateToken.balanceOf.returns(0);
+          await DCAHubSwapper.connect(hub).DCAHubSwapCall(constants.ZERO_ADDRESS, [], [], data);
+        });
+        then('balance is called correctly', () => {
+          expect(intermediateToken.balanceOf).to.have.been.calledOnceWith(DCAHubSwapper.address);
+        });
+        then('it is not transferred', () => {
+          expect(intermediateToken.transfer).to.not.have.been.called;
+        });
+      });
+    });
+
+    type SwapWithDexes = {
+      deadline?: BigNumberish;
+      allowanceTargets?: { token: string; spender: string; amount: BigNumberish }[];
+      executions?: { data: BytesLike; swapper: string }[];
+      extraTokens?: string[];
+      leftoverRecipient?: { address: string };
+      sendToProvideLeftoverToHub?: boolean;
+    };
+    function encode(bytes: SwapWithDexes) {
+      return ABI_CODER.encode(
+        ['tuple(uint256, tuple(address, address, uint256)[], tuple(address, bytes)[], address[], address, bool)'],
+        [
+          [
+            bytes.deadline ?? constants.MAX_UINT_256,
+            bytes.allowanceTargets?.map(({ token, spender, amount }) => [token, spender, amount]) ?? [],
+            bytes.executions?.map(({ swapper, data }) => [swapper, data]) ?? [],
+            bytes.extraTokens ?? [],
+            bytes.leftoverRecipient?.address ?? recipient.address,
+            bytes.sendToProvideLeftoverToHub ?? false,
+          ],
+        ]
+      );
+    }
+  });
+});

--- a/test/unit/DCAHubSwapper/third-party-dca-hub-swapper.spec.ts
+++ b/test/unit/DCAHubSwapper/third-party-dca-hub-swapper.spec.ts
@@ -13,7 +13,7 @@ import { utils } from 'ethers';
 
 chai.use(smock.matchers);
 
-contract.only('ThirdPartyDCAHubSwapper', () => {
+contract('ThirdPartyDCAHubSwapper', () => {
   const ABI_CODER = new utils.AbiCoder();
   let recipient: SignerWithAddress, hub: SignerWithAddress;
   let DCAHubSwapper: ThirdPartyDCAHubSwapper;


### PR DESCRIPTION
We are now introducing a new DCA Swapper. This Swapper is meant to only support third-party swaps, not swaps for caller
This means that no-one should be approving tokens for this contract. Since that's the case, and the contract is not meant to hold any tokens, we can call any arbitrary data

Therefore, we can avoid using the TransformerRegistry and interact with 4626s directly 🚀 

Also, in the existing swapper, the workflow is DCASwapper => DCAHub => DCASwapper

Now, we only do DCAHub => DCASwapper, which should be much cheaper in terms of gas 🤑 

