### PR TITLE
refactor: rename old swapper

### DIFF
--- a/contracts/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol
+++ b/contracts/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol
@@ -7,7 +7,7 @@ import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '../interfaces/IDCAHubSwapper.sol';
 import './utils/DeadlineValidation.sol';
 
-contract DCAHubSwapper is DeadlineValidation, AccessControl, GetBalances, IDCAHubSwapper {
+contract CallerOnlyDCAHubSwapper is DeadlineValidation, AccessControl, GetBalances, IDCAHubSwapper {
   using SafeERC20 for IERC20;
   using Address for address;
 

--- a/contracts/mocks/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol
+++ b/contracts/mocks/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.7 <0.9.0;
 
-import '../../DCAHubSwapper/DCAHubSwapper.sol';
+import '../../DCAHubSwapper/CallerOnlyDCAHubSwapper.sol';
 
-contract DCAHubSwapperMock is DCAHubSwapper {
+contract CallerOnlyDCAHubSwapperMock is CallerOnlyDCAHubSwapper {
   struct MaxApproveSpenderCall {
     IERC20 token;
     address spender;
@@ -32,7 +32,7 @@ contract DCAHubSwapperMock is DCAHubSwapper {
     address _superAdmin,
     address[] memory _initialAdmins,
     address[] memory _initialSwapExecutors
-  ) DCAHubSwapper(_swapperRegistry, _superAdmin, _initialAdmins, _initialSwapExecutors) {}
+  ) CallerOnlyDCAHubSwapper(_swapperRegistry, _superAdmin, _initialAdmins, _initialSwapExecutors) {}
 
   function maxApproveSpenderCalls() external view returns (MaxApproveSpenderCall[] memory) {
     return _maxApproveSpenderCalls;

--- a/deploy/002_caller_only_swapper.ts
+++ b/deploy/002_caller_only_swapper.ts
@@ -1,6 +1,6 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from '@0xged/hardhat-deploy/types';
-import { bytecode } from '../artifacts/contracts/DCAHubSwapper/DCAHubSwapper.sol/DCAHubSwapper.json';
+import { bytecode } from '../artifacts/contracts/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol/CallerOnlyDCAHubSwapper.json';
 import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-factory/utils/deployment';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -10,9 +10,9 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
 
   await deployThroughDeterministicFactory({
     deployer,
-    name: 'DCAHubSwapper',
-    salt: 'MF-DCAV2-DCAHubSwapper-V1',
-    contract: 'contracts/DCAHubSwapper/DCAHubSwapper.sol:DCAHubSwapper',
+    name: 'DCAHubSwapper', // We will use the old name to avoid re-deploying
+    salt: 'MF-DCAV2-CallerDCAHubSwapper-V1',
+    contract: 'contracts/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol:CallerOnlyDCAHubSwapper',
     bytecode,
     constructorArgs: {
       types: ['address', 'address', 'address[]', 'address[]'],
@@ -28,5 +28,5 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
 };
 
 deployFunction.dependencies = [];
-deployFunction.tags = ['DCAHubSwapper'];
+deployFunction.tags = ['DCAHubSwapper']; // We will use the old name to avoid re-deploying
 export default deployFunction;

--- a/deploy/002_caller_only_swapper.ts
+++ b/deploy/002_caller_only_swapper.ts
@@ -28,5 +28,5 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
 };
 
 deployFunction.dependencies = [];
-deployFunction.tags = ['CallerOnlyDCAHubSwapper']; // We will use the old name to avoid re-deploying
+deployFunction.tags = ['CallerOnlyDCAHubSwapper'];
 export default deployFunction;

--- a/deploy/002_caller_only_swapper.ts
+++ b/deploy/002_caller_only_swapper.ts
@@ -10,7 +10,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
 
   await deployThroughDeterministicFactory({
     deployer,
-    name: 'DCAHubSwapper', // We will use the old name to avoid re-deploying
+    name: 'CallerOnlyDCAHubSwapper',
     salt: 'MF-DCAV2-CallerDCAHubSwapper-V1',
     contract: 'contracts/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol:CallerOnlyDCAHubSwapper',
     bytecode,
@@ -28,5 +28,5 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
 };
 
 deployFunction.dependencies = [];
-deployFunction.tags = ['DCAHubSwapper']; // We will use the old name to avoid re-deploying
+deployFunction.tags = ['CallerOnlyDCAHubSwapper']; // We will use the old name to avoid re-deploying
 export default deployFunction;

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -4,7 +4,7 @@ import { JsonRpcSigner } from '@ethersproject/providers';
 import { constants, wallet } from '@test-utils';
 import { contract } from '@test-utils/bdd';
 import evm from '@test-utils/evm';
-import { DCAHubSwapper, IERC20, DCAFeeManager, ISwapperRegistry } from '@typechained';
+import { CallerOnlyDCAHubSwapper, IERC20, DCAFeeManager, ISwapperRegistry } from '@typechained';
 import { DCAHub } from '@mean-finance/dca-v2-core';
 import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
 import { BigNumber, utils } from 'ethers';
@@ -29,7 +29,7 @@ contract('DCAFeeManager', () => {
   let superAdmin: JsonRpcSigner;
   let cindy: SignerWithAddress, allowed: SignerWithAddress, swapper: SignerWithAddress;
   let DCAFeeManager: DCAFeeManager;
-  let DCAHubSwapper: DCAHubSwapper;
+  let DCAHubSwapper: CallerOnlyDCAHubSwapper;
   let DCAHub: DCAHub;
   let transformerRegistry: TransformerRegistry;
   let swapperRegistry: ISwapperRegistry;

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -44,7 +44,7 @@ contract('DCAFeeManager', () => {
     ({ msig: superAdmin } = await deploy('DCAFeeManager'));
 
     DCAHub = await ethers.getContract('DCAHub');
-    DCAHubSwapper = await ethers.getContract('DCAHubSwapper');
+    DCAHubSwapper = await ethers.getContract('CallerOnlyDCAHubSwapper');
     DCAFeeManager = await ethers.getContract('DCAFeeManager');
     transformerRegistry = await ethers.getContract('TransformerRegistry');
     swapperRegistry = await ethers.getContract('SwapperRegistry');

--- a/test/integration/DCAHubCompanion/multi-call.spec.ts
+++ b/test/integration/DCAHubCompanion/multi-call.spec.ts
@@ -4,7 +4,7 @@ import { TransactionResponse } from '@ethersproject/providers';
 import { constants, wallet } from '@test-utils';
 import { contract, given, then, when } from '@test-utils/bdd';
 import evm, { snapshot } from '@test-utils/evm';
-import { DCAHubCompanion, DCAHubSwapper, IERC20 } from '@typechained';
+import { DCAHubCompanion, CallerOnlyDCAHubSwapper, IERC20 } from '@typechained';
 import { DCAHub, DCAPermissionsManager } from '@mean-finance/dca-v2-core';
 import { TransformerRegistry } from '@mean-finance/transformers';
 import { SwapperRegistry } from '@mean-finance/swappers';
@@ -35,7 +35,7 @@ contract('Multicall', () => {
   let DCAHubCompanion: DCAHubCompanion;
   let DCAPermissionManager: DCAPermissionsManager;
   let DCAHub: DCAHub;
-  let DCAHubSwapper: DCAHubSwapper;
+  let DCAHubSwapper: CallerOnlyDCAHubSwapper;
   let transformerRegistry: TransformerRegistry;
   let chainId: BigNumber;
   let snapshotId: string;

--- a/test/integration/DCAHubCompanion/multi-call.spec.ts
+++ b/test/integration/DCAHubCompanion/multi-call.spec.ts
@@ -50,7 +50,7 @@ contract('Multicall', () => {
 
     DCAHub = await ethers.getContract('DCAHub');
     DCAHubCompanion = await ethers.getContract('DCAHubCompanion');
-    DCAHubSwapper = await ethers.getContract('DCAHubSwapper');
+    DCAHubSwapper = await ethers.getContract('CallerOnlyDCAHubSwapper');
     DCAPermissionManager = await ethers.getContract('PermissionsManager');
     transformerRegistry = await ethers.getContract('TransformerRegistry');
 

--- a/test/integration/DCAHubSwapper/swap-for-caller.spec.ts
+++ b/test/integration/DCAHubSwapper/swap-for-caller.spec.ts
@@ -41,7 +41,7 @@ contract('Swap for caller', () => {
     ({ msig: governor } = await deploy());
 
     DCAHub = await ethers.getContract('DCAHub');
-    DCAHubSwapper = await ethers.getContract('DCAHubSwapper');
+    DCAHubSwapper = await ethers.getContract('CallerOnlyDCAHubSwapper');
 
     // Allow tokens
     await DCAHub.connect(governor).setAllowedTokens([WETH_ADDRESS, USDC_ADDRESS], [true, true]);

--- a/test/integration/DCAHubSwapper/swap-for-caller.spec.ts
+++ b/test/integration/DCAHubSwapper/swap-for-caller.spec.ts
@@ -4,7 +4,7 @@ import { JsonRpcSigner, TransactionResponse } from '@ethersproject/providers';
 import { constants, wallet } from '@test-utils';
 import { contract, given, then, when } from '@test-utils/bdd';
 import evm, { snapshot } from '@test-utils/evm';
-import { DCAHubSwapper, IERC20 } from '@typechained';
+import { CallerOnlyDCAHubSwapper, IERC20 } from '@typechained';
 import { DCAHub } from '@mean-finance/dca-v2-core';
 import { abi as DCA_HUB_ABI } from '@mean-finance/dca-v2-core/artifacts/contracts/DCAHub/DCAHub.sol/DCAHub.json';
 import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
@@ -23,7 +23,7 @@ contract('Swap for caller', () => {
   let WETH: IERC20, USDC: IERC20;
   let governor: JsonRpcSigner;
   let cindy: SignerWithAddress, swapper: SignerWithAddress, recipient: SignerWithAddress;
-  let DCAHubSwapper: DCAHubSwapper;
+  let DCAHubSwapper: CallerOnlyDCAHubSwapper;
   let DCAHub: DCAHub;
   let initialPerformedSwaps: number;
   let snapshotId: string;

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -36,7 +36,7 @@ export async function deployWithAddress(
       'TransformerRegistry',
       'SwapperRegistry',
       'DCAHub',
-      'DCAHubSwapper',
+      'CallerOnlyDCAHubSwapper',
       ...contracts,
     ],
     {

--- a/test/unit/DCAHubSwapper/caller-only-dca-hub-swapper.spec.ts
+++ b/test/unit/DCAHubSwapper/caller-only-dca-hub-swapper.spec.ts
@@ -4,7 +4,7 @@ import { behaviours, constants, wallet } from '@test-utils';
 import { contract, given, then, when } from '@test-utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { snapshot } from '@test-utils/evm';
-import { DCAHubSwapperMock, DCAHubSwapperMock__factory, IDCAHub, IERC20, ISwapperRegistry } from '@typechained';
+import { CallerOnlyDCAHubSwapperMock, CallerOnlyDCAHubSwapperMock__factory, IDCAHub, IERC20, ISwapperRegistry } from '@typechained';
 import { FakeContract, smock } from '@defi-wonderland/smock';
 import { BigNumberish } from '@ethersproject/bignumber';
 import { BytesLike } from '@ethersproject/bytes';
@@ -12,12 +12,12 @@ import { utils } from 'ethers';
 
 chai.use(smock.matchers);
 
-contract('DCAHubSwapper', () => {
+contract('CallerOnlyDCAHubSwapper', () => {
   const BYTES = utils.hexlify(utils.randomBytes(10));
   let swapExecutioner: SignerWithAddress, recipient: SignerWithAddress, admin: SignerWithAddress, superAdmin: SignerWithAddress;
   let DCAHub: FakeContract<IDCAHub>;
-  let DCAHubSwapperFactory: DCAHubSwapperMock__factory;
-  let DCAHubSwapper: DCAHubSwapperMock;
+  let DCAHubSwapperFactory: CallerOnlyDCAHubSwapperMock__factory;
+  let DCAHubSwapper: CallerOnlyDCAHubSwapperMock;
   let swapperRegistry: FakeContract<ISwapperRegistry>;
   let tokenA: FakeContract<IERC20>, tokenB: FakeContract<IERC20>, intermediateToken: FakeContract<IERC20>;
   let swapExecutionRole: string, adminRole: string, superAdminRole: string;
@@ -28,7 +28,9 @@ contract('DCAHubSwapper', () => {
 
   before('Setup accounts and contracts', async () => {
     [, swapExecutioner, admin, recipient, superAdmin] = await ethers.getSigners();
-    DCAHubSwapperFactory = await ethers.getContractFactory('contracts/mocks/DCAHubSwapper/DCAHubSwapper.sol:DCAHubSwapperMock');
+    DCAHubSwapperFactory = await ethers.getContractFactory(
+      'contracts/mocks/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol:CallerOnlyDCAHubSwapperMock'
+    );
     DCAHub = await smock.fake('IDCAHub');
     swapperRegistry = await smock.fake('ISwapperRegistry');
     DCAHubSwapper = await DCAHubSwapperFactory.deploy(swapperRegistry.address, superAdmin.address, [admin.address], [swapExecutioner.address]);
@@ -311,7 +313,7 @@ contract('DCAHubSwapper', () => {
     }
     throw new Error('Unknown address');
   }
-  function whenDeadlineHasExpiredThenTxReverts({ func, args }: { func: keyof DCAHubSwapperMock['functions']; args: () => any[] }) {
+  function whenDeadlineHasExpiredThenTxReverts({ func, args }: { func: keyof CallerOnlyDCAHubSwapperMock['functions']; args: () => any[] }) {
     when('deadline has expired', () => {
       then('reverts with message', async () => {
         await behaviours.txShouldRevertWithMessage({


### PR DESCRIPTION
We are renaming the old swapper so that it's clear that it will only support "swap for caller" only