### PR TITLE
feat: add execute swap

### DIFF
--- a/test/integration/DCAHubSwapper/multi-pair-swap-with-dex.spec.ts
+++ b/test/integration/DCAHubSwapper/multi-pair-swap-with-dex.spec.ts
@@ -207,12 +207,12 @@ contract('Multi pair swap with DEX', () => {
   };
   function encode(bytes: SwapData) {
     return ABI_CODER.encode(
-      ['tuple(uint256, tuple(address, address, uint256)[], tuple(address, bytes)[], address[], address, bool)'],
+      ['tuple(uint256, tuple(address, address, uint256)[], tuple(address, uint256, bytes)[], address[], address, bool)'],
       [
         [
           constants.MAX_UINT_256,
           bytes.allowanceTargets?.map(({ token, spender, amount }) => [token, spender, amount]) ?? [],
-          bytes.executions?.map(({ swapper, data }) => [swapper, data]) ?? [],
+          bytes.executions?.map(({ swapper, data }) => [swapper, 0, data]) ?? [],
           bytes.extraTokens ?? [],
           recipient.address,
           bytes.sendToProvideLeftoverToHub ?? false,

--- a/test/integration/DCAKeep3rJob/keep3r-job.spec.ts
+++ b/test/integration/DCAKeep3rJob/keep3r-job.spec.ts
@@ -223,12 +223,12 @@ contract('DCAKeep3rJob', () => {
   function encodeSwap(bytes: SwapData) {
     const abiCoder = new utils.AbiCoder();
     return abiCoder.encode(
-      ['tuple(uint256, tuple(address, address, uint256)[], tuple(address, bytes)[], address[], address, bool)'],
+      ['tuple(uint256, tuple(address, address, uint256)[], tuple(address, uint256, bytes)[], address[], address, bool)'],
       [
         [
           constants.MAX_UINT_256,
           bytes.allowanceTargets.map(({ token, spender, amount }) => [token, spender, amount]),
-          bytes.executions.map(({ swapper, data }) => [swapper, data]),
+          bytes.executions.map(({ swapper, data }) => [swapper, 0, data]),
           bytes.extraTokens,
           bytes.leftoverRecipient.address,
           bytes.sendToProvideLeftoverToHub,

--- a/test/unit/DCAHubSwapper/third-party-dca-hub-swapper.spec.ts
+++ b/test/unit/DCAHubSwapper/third-party-dca-hub-swapper.spec.ts
@@ -262,12 +262,12 @@ contract('ThirdPartyDCAHubSwapper', () => {
     };
     function encode(bytes: SwapWithDexes) {
       return ABI_CODER.encode(
-        ['tuple(uint256, tuple(address, address, uint256)[], tuple(address, bytes)[], address[], address, bool)'],
+        ['tuple(uint256, tuple(address, address, uint256)[], tuple(address, uint256, bytes)[], address[], address, bool)'],
         [
           [
             bytes.deadline ?? constants.MAX_UINT_256,
             bytes.allowanceTargets?.map(({ token, spender, amount }) => [token, spender, amount]) ?? [],
-            bytes.executions?.map(({ swapper, data }) => [swapper, data]) ?? [],
+            bytes.executions?.map(({ swapper, data }) => [swapper, 0, data]) ?? [],
             bytes.extraTokens ?? [],
             bytes.leftoverRecipient?.address ?? recipient.address,
             bytes.sendToProvideLeftoverToHub ?? false,


### PR DESCRIPTION
There are some cases where the oracles differ from what the markets can offer, so a swap can't be executed. But it could happen that even if the amounts being swap are really big, the difference between oracle and market is only a few dollars. In that case, it would be nice if someone could just pay for the difference.
The idea here is that instead of calling the hub directly, someone could call the swapper with some native token, so that when the swapper gets called, they can use that native token balance as part of the swap, and cover the difference

The normal workflow is:
`Caller => Hub => Swapper => Hub`

Here, it would be:
`Caller => Swapper => Hub => Swapper => Hub`

It would be more expensive, but again, it would be optional

_Note: this change required us to include a new property `value` in `SwapExecution`. It would make normal swaps (that start on the Hub) a little more expensive. It's hard to understand how much, since we can't do gas tests on calls that start on the hub (I hate you hardhat), but we would only be adding 1 uint full of zeros to the calldata_