### PR TITLE
feat: add multi permission permit to companion

### DIFF
--- a/contracts/DCAHubCompanion/DCAHubCompanionHubProxyHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionHubProxyHandler.sol
@@ -19,6 +19,18 @@ abstract contract DCAHubCompanionHubProxyHandler is IDCAHubCompanionHubProxyHand
   }
 
   /// @inheritdoc IDCAHubCompanionHubProxyHandler
+  function multiPermissionPermit(
+    IDCAPermissionManager _permissionManager,
+    IDCAPermissionManager.PositionPermissions[] calldata _permissions,
+    uint256 _deadline,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  ) external payable {
+    _permissionManager.multiPermissionPermit(_permissions, _deadline, _v, _r, _s);
+  }
+
+  /// @inheritdoc IDCAHubCompanionHubProxyHandler
   function deposit(
     IDCAHub _hub,
     address _from,

--- a/contracts/interfaces/IDCAHubCompanion.sol
+++ b/contracts/interfaces/IDCAHubCompanion.sol
@@ -199,6 +199,24 @@ interface IDCAHubCompanionHubProxyHandler {
   ) external payable returns (uint256 unswapped, uint256 swapped);
 
   /**
+   * @notice Calls the permission manager and sets multiple permissions via signature
+   * @param permissionManager The address of the permission manager
+   * @param permissions The permissions to set
+   * @param deadline The deadline timestamp by which the call must be mined for the approve to work
+   * @param v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+   * @param r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+   * @param s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+   */
+  function multiPermissionPermit(
+    IDCAPermissionManager permissionManager,
+    IDCAPermissionManager.PositionPermissions[] calldata permissions,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external payable;
+
+  /**
    * @notice Calls the permission manager and sets permissions via signature
    * @param permissionManager The address of the permission manager
    * @param permissions The permissions to set

--- a/test/unit/DCAHubCompanion/dca-hub-companion-hub-proxy-handler.spec.ts
+++ b/test/unit/DCAHubCompanion/dca-hub-companion-hub-proxy-handler.spec.ts
@@ -92,6 +92,36 @@ contract('DCAHubCompanionHubProxyHandler', () => {
     });
   });
 
+  const MULTI_PERMISSIONS = [
+    {
+      tokenId: 10,
+      permissionSets: PERMISSIONS,
+    },
+  ];
+  describe('multiPermissionPermit', () => {
+    const R = utils.formatBytes32String('r');
+    const S = utils.formatBytes32String('s');
+
+    when('method is executed', () => {
+      given(async () => {
+        await DCAHubCompanionHubProxyHandler.multiPermissionPermit(DCAPermissionManager.address, MULTI_PERMISSIONS, 20, 30, R, S);
+      });
+      then('hub is called', () => {
+        expect(DCAPermissionManager.multiPermissionPermit).to.have.been.calledOnce;
+        const [permissions, deadline, v, r, s] = DCAPermissionManager.multiPermissionPermit.getCall(0).args;
+        expect((permissions as any).length).to.equal(MULTI_PERMISSIONS.length);
+        expect((permissions as any)[0].tokenId).to.equal(10);
+        expect((permissions as any)[0].permissionSets.length).to.equal(1);
+        expect((permissions as any)[0].permissionSets[0].operator).to.equal(PERMISSIONS[0].operator);
+        expect((permissions as any)[0].permissionSets[0].permissions).to.eql(PERMISSIONS[0].permissions);
+        expect(deadline).to.equal(20);
+        expect(v).to.equal(30);
+        expect(r).to.equal(R);
+        expect(s).to.equal(S);
+      });
+    });
+  });
+
   describe('deposit', () => {
     const TO = '0x0000000000000000000000000000000000000002';
     const AMOUNT = 10000;


### PR DESCRIPTION
We are now simply adding a new call to the companion. This call will allow us to execute multi-permissions. These are signature permissions that modify multiple positions, with only one signature

This call doesn't need any checks, since it's just about sending the signature permit to the permission manager