### PR TITLE
feat: add take with permit to base companion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
         timeout-minutes: 15
 
   integration:
+    needs: ["unit"]
     runs-on: ubuntu-latest
     steps:
       - name: Check out github repository

--- a/contracts/DCAHubCompanion/DCAHubCompanion.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanion.sol
@@ -6,5 +6,9 @@ import './DCAHubCompanionHubProxyHandler.sol';
 import '../utils/BaseCompanion.sol';
 
 contract DCAHubCompanion is DCAHubCompanionLibrariesHandler, DCAHubCompanionHubProxyHandler, BaseCompanion, IDCAHubCompanion {
-  constructor(address _swapperRegistry, address _governor) BaseCompanion(_swapperRegistry, _governor) {}
+  constructor(
+    address _swapperRegistry,
+    address _governor,
+    IPermit2 _permit2
+  ) BaseCompanion(_swapperRegistry, _governor, _permit2) {}
 }

--- a/contracts/DCAHubCompanion/DCAHubCompanion.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanion.sol
@@ -7,8 +7,9 @@ import '../utils/BaseCompanion.sol';
 
 contract DCAHubCompanion is DCAHubCompanionLibrariesHandler, DCAHubCompanionHubProxyHandler, BaseCompanion, IDCAHubCompanion {
   constructor(
-    address _swapperRegistry,
+    address _swapper,
+    address _allowanceTarget,
     address _governor,
     IPermit2 _permit2
-  ) BaseCompanion(_swapperRegistry, _governor, _permit2) {}
+  ) BaseCompanion(_swapper, _allowanceTarget, _governor, _permit2) {}
 }

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.7 <0.9.0;
 
 import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHub.sol';
-import '@mean-finance/swappers/solidity/contracts/extensions/RunSwap.sol';
 import '@mean-finance/swappers/solidity/contracts/extensions/TakeManyRunSwapsAndTransferMany.sol';
 
 /**
@@ -13,6 +12,20 @@ import '@mean-finance/swappers/solidity/contracts/extensions/TakeManyRunSwapsAnd
  *         of their choosing
  */
 interface IDCAFeeManager {
+  /// @notice The parameters to execute the call
+  struct RunSwapsAndTransferManyParams {
+    // The accounts that should be approved for spending
+    Allowance[] allowanceTargets;
+    // The different swappers involved in the swap
+    address[] swappers;
+    // The different swapps to execute
+    bytes[] swaps;
+    // Context necessary for the swap execution
+    SwapContext[] swapContext;
+    // Tokens to transfer after swaps have been executed
+    TransferOutBalance[] transferOutBalance;
+  }
+
   /// @notice Represents a share of a target token
   struct TargetTokenShare {
     address token;
@@ -69,22 +82,11 @@ interface IDCAFeeManager {
   function positions(bytes32 pairKey) external view returns (uint256); // key(from, to) => position id
 
   /**
-   * @notice Executes a swap with the given swapper. The input tokens are expected to be on the contract before
-   *         this function is executed. If the swap doesn't include a transfer, then the swapped tokens will be left
-   *         on the contract
-   * @dev This function can only be executed with swappers that are allowlisted. Can only be executed by admins
-   * @param parameters The parameters for the swap
-   */
-  function runSwap(RunSwap.RunSwapParams calldata parameters) external payable;
-
-  /**
    * @notice Executes multiple swaps
-   * @dev This function can only be executed with swappers that are allowlisted. Can only be executed by admins
+   * @dev Can only be executed by admins
    * @param parameters The parameters for the swap
    */
-  function takeManyRunSwapsAndTransferMany(TakeManyRunSwapsAndTransferMany.TakeManyRunSwapsAndTransferManyParams calldata parameters)
-    external
-    payable;
+  function runSwapsAndTransferMany(RunSwapsAndTransferManyParams calldata parameters) external payable;
 
   /**
    * @notice Withdraws tokens from the platform balance, and sends them to the given recipient

--- a/contracts/interfaces/external/IPermit2.sol
+++ b/contracts/interfaces/external/IPermit2.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.0;
+
+// Minimal Permit2 interface, derived from
+// https://github.com/Uniswap/permit2/blob/main/src/interfaces/ISignatureTransfer.sol
+interface IPermit2 {
+  struct TokenPermissions {
+    address token;
+    uint256 amount;
+  }
+
+  struct PermitTransferFrom {
+    TokenPermissions permitted;
+    uint256 nonce;
+    uint256 deadline;
+  }
+
+  struct PermitBatchTransferFrom {
+    TokenPermissions[] permitted;
+    uint256 nonce;
+    uint256 deadline;
+  }
+
+  struct SignatureTransferDetails {
+    address to;
+    uint256 requestedAmount;
+  }
+
+  function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+  function permitTransferFrom(
+    PermitTransferFrom calldata permit,
+    SignatureTransferDetails calldata transferDetails,
+    address owner,
+    bytes calldata signature
+  ) external;
+
+  function permitTransferFrom(
+    PermitBatchTransferFrom memory permit,
+    SignatureTransferDetails[] calldata transferDetails,
+    address owner,
+    bytes calldata signature
+  ) external;
+}

--- a/contracts/interfaces/external/IPermit2.sol
+++ b/contracts/interfaces/external/IPermit2.sol
@@ -26,6 +26,7 @@ interface IPermit2 {
     uint256 requestedAmount;
   }
 
+  // solhint-disable-next-line func-name-mixedcase
   function DOMAIN_SEPARATOR() external view returns (bytes32);
 
   function permitTransferFrom(

--- a/contracts/libraries/Permit2Transfers.sol
+++ b/contracts/libraries/Permit2Transfers.sol
@@ -17,6 +17,7 @@ library Permit2Transfers {
    * @param _nonce The owner's nonce
    * @param _deadline The signature's expiration deadline
    * @param _signature The signature that allows the transfer
+   * @param _recipient The address that will receive the funds
    */
   function takeFromCaller(
     IPermit2 _permit2,
@@ -24,13 +25,14 @@ library Permit2Transfers {
     uint256 _amount,
     uint256 _nonce,
     uint256 _deadline,
-    bytes calldata _signature
+    bytes calldata _signature,
+    address _recipient
   ) internal {
     _permit2.permitTransferFrom(
       // The permit message.
       IPermit2.PermitTransferFrom({permitted: IPermit2.TokenPermissions({token: _token, amount: _amount}), nonce: _nonce, deadline: _deadline}),
       // The transfer recipient and amount.
-      IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: _amount}),
+      IPermit2.SignatureTransferDetails({to: _recipient, requestedAmount: _amount}),
       // The owner of the tokens, which must also be
       // the signer of the message, otherwise this call
       // will fail.
@@ -48,20 +50,22 @@ library Permit2Transfers {
    * @param _nonce The owner's nonce
    * @param _deadline The signature's expiration deadline
    * @param _signature The signature that allows the transfer
+   * @param _recipient The address that will receive the funds
    */
   function batchTakeFromCaller(
     IPermit2 _permit2,
     IPermit2.TokenPermissions[] calldata _tokens,
     uint256 _nonce,
     uint256 _deadline,
-    bytes calldata _signature
+    bytes calldata _signature,
+    address _recipient
   ) internal {
     if (_tokens.length > 0) {
       _permit2.permitTransferFrom(
         // The permit message.
         IPermit2.PermitBatchTransferFrom({permitted: _tokens, nonce: _nonce, deadline: _deadline}),
         // The transfer recipients and amounts.
-        _buildTransferDetails(_tokens),
+        _buildTransferDetails(_tokens, _recipient),
         // The owner of the tokens, which must also be
         // the signer of the message, otherwise this call
         // will fail.
@@ -73,14 +77,14 @@ library Permit2Transfers {
     }
   }
 
-  function _buildTransferDetails(IPermit2.TokenPermissions[] calldata _tokens)
+  function _buildTransferDetails(IPermit2.TokenPermissions[] calldata _tokens, address _recipient)
     private
-    view
+    pure
     returns (IPermit2.SignatureTransferDetails[] memory _details)
   {
     _details = new IPermit2.SignatureTransferDetails[](_tokens.length);
     for (uint256 i; i < _details.length; ) {
-      _details[i] = IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: _tokens[i].amount});
+      _details[i] = IPermit2.SignatureTransferDetails({to: _recipient, requestedAmount: _tokens[i].amount});
       unchecked {
         ++i;
       }

--- a/contracts/libraries/Permit2Transfers.sol
+++ b/contracts/libraries/Permit2Transfers.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.0;
+
+import {IPermit2} from '../interfaces/external/IPermit2.sol';
+
+/**
+ * @title Permit2 Transfers Library
+ * @author Sam Bugs
+ * @notice A small library to call Permit2's transfer from methods
+ */
+library Permit2Transfers {
+  /**
+   * @notice Executes a transfer from using Permit2
+   * @param _permit2 The Permit2 contract
+   * @param _token The token to transfer
+   * @param _amount The amount to transfer
+   * @param _nonce The owner's nonce
+   * @param _deadline The signature's expiration deadline
+   * @param _signature The signature that allows the transfer
+   */
+  function takeFromCaller(
+    IPermit2 _permit2,
+    address _token,
+    uint256 _amount,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes calldata _signature
+  ) internal {
+    _permit2.permitTransferFrom(
+      // The permit message.
+      IPermit2.PermitTransferFrom({permitted: IPermit2.TokenPermissions({token: _token, amount: _amount}), nonce: _nonce, deadline: _deadline}),
+      // The transfer recipient and amount.
+      IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: _amount}),
+      // The owner of the tokens, which must also be
+      // the signer of the message, otherwise this call
+      // will fail.
+      msg.sender,
+      // The packed signature that was the result of signing
+      // the EIP712 hash of `permit`.
+      _signature
+    );
+  }
+
+  /**
+   * @notice Executes a batch transfer from using Permit2
+   * @param _permit2 The Permit2 contract
+   * @param _tokens The amount of tokens to transfer
+   * @param _nonce The owner's nonce
+   * @param _deadline The signature's expiration deadline
+   * @param _signature The signature that allows the transfer
+   */
+  function batchTakeFromCaller(
+    IPermit2 _permit2,
+    IPermit2.TokenPermissions[] calldata _tokens,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes calldata _signature
+  ) internal {
+    if (_tokens.length > 0) {
+      _permit2.permitTransferFrom(
+        // The permit message.
+        IPermit2.PermitBatchTransferFrom({permitted: _tokens, nonce: _nonce, deadline: _deadline}),
+        // The transfer recipients and amounts.
+        _buildTransferDetails(_tokens),
+        // The owner of the tokens, which must also be
+        // the signer of the message, otherwise this call
+        // will fail.
+        msg.sender,
+        // The packed signature that was the result of signing
+        // the EIP712 hash of `permit`.
+        _signature
+      );
+    }
+  }
+
+  function _buildTransferDetails(IPermit2.TokenPermissions[] calldata _tokens)
+    private
+    view
+    returns (IPermit2.SignatureTransferDetails[] memory _details)
+  {
+    _details = new IPermit2.SignatureTransferDetails[](_tokens.length);
+    for (uint256 i; i < _details.length; ) {
+      _details[i] = IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: _tokens[i].amount});
+      unchecked {
+        ++i;
+      }
+    }
+  }
+}

--- a/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
@@ -19,11 +19,7 @@ contract DCAFeeManagerMock is DCAFeeManager {
   SendBalanceOnContractToRecipientCall[] internal _sendBalanceOnContractToRecipientCalls;
   RevokeAction[][] internal _revokeCalls;
 
-  constructor(
-    address _swapperRegistry,
-    address _superAdmin,
-    address[] memory _initialAdmins
-  ) DCAFeeManager(_swapperRegistry, _superAdmin, _initialAdmins) {}
+  constructor(address _superAdmin, address[] memory _initialAdmins) DCAFeeManager(_superAdmin, _initialAdmins) {}
 
   function sendBalanceOnContractToRecipientCalls() external view returns (SendBalanceOnContractToRecipientCall[] memory) {
     return _sendBalanceOnContractToRecipientCalls;

--- a/contracts/mocks/utils/BaseCompanion.sol
+++ b/contracts/mocks/utils/BaseCompanion.sol
@@ -4,7 +4,11 @@ pragma solidity >=0.8.7 <0.9.0;
 import '../../utils/BaseCompanion.sol';
 
 contract BaseCompanionMock is BaseCompanion {
-  constructor(address _swapperRegistry, address _governor) BaseCompanion(_swapperRegistry, _governor) {}
+  constructor(
+    address _swapperRegistry,
+    address _governor,
+    IPermit2 _permit2
+  ) BaseCompanion(_swapperRegistry, _governor, _permit2) {}
 
   struct TakeFromMsgSenderCall {
     IERC20 token;

--- a/contracts/mocks/utils/BaseCompanion.sol
+++ b/contracts/mocks/utils/BaseCompanion.sol
@@ -5,10 +5,11 @@ import '../../utils/BaseCompanion.sol';
 
 contract BaseCompanionMock is BaseCompanion {
   constructor(
-    address _swapperRegistry,
+    address _swapper,
+    address _allowanceTarget,
     address _governor,
     IPermit2 _permit2
-  ) BaseCompanion(_swapperRegistry, _governor, _permit2) {}
+  ) BaseCompanion(_swapper, _allowanceTarget, _governor, _permit2) {}
 
   struct TakeFromMsgSenderCall {
     IERC20 token;

--- a/contracts/utils/BaseCompanion.sol
+++ b/contracts/utils/BaseCompanion.sol
@@ -5,15 +5,31 @@ import '@mean-finance/swappers/solidity/contracts/extensions/GetBalances.sol';
 import '@mean-finance/swappers/solidity/contracts/extensions/RevokableWithGovernor.sol';
 import '@mean-finance/swappers/solidity/contracts/extensions/RunSwap.sol';
 import '@mean-finance/swappers/solidity/contracts/extensions/PayableMulticall.sol';
-import '@mean-finance/swappers/solidity/contracts/extensions/TokenPermit.sol';
+import {IPermit2} from '../interfaces/external/IPermit2.sol';
+import {Permit2Transfers} from '../libraries/Permit2Transfers.sol';
 
 /**
  * @notice This contract will work as base companion for all our contracts. It will extend the capabilities of our companion
  *         contracts so that they can execute multicalls, swaps, revokes and more
  * @dev All public functions are payable, so that they can be multicalled together with other payable functions when msg.value > 0
  */
-abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, PayableMulticall, TokenPermit {
-  constructor(address _swapperRegistry, address _governor) SwapAdapter(_swapperRegistry) Governable(_governor) {}
+abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, PayableMulticall {
+  using Permit2Transfers for IPermit2;
+
+  /**
+   * @notice Returns the address of the Permit2 contract
+   * @dev This value is constant and cannot change
+   * @return The address of the Permit2 contract
+   */
+  IPermit2 public immutable PERMIT2;
+
+  constructor(
+    address _swapperRegistry,
+    address _governor,
+    IPermit2 _permit2
+  ) SwapAdapter(_swapperRegistry) Governable(_governor) {
+    PERMIT2 = _permit2;
+  }
 
   /**
    * @notice Sends the specified amount of the given token to the recipient
@@ -36,6 +52,40 @@ abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, 
    */
   function takeFromCaller(IERC20 _token, uint256 _amount) external payable {
     _takeFromMsgSender(_token, _amount);
+  }
+
+  /**
+   * @notice Takes the given amount of tokens from the caller with Permit2 and transfers it to this contract
+   * @param _token The token to take
+   * @param _amount The amount to take
+   * @param _nonce The signed nonce
+   * @param _deadline The signature's deadline
+   * @param _signature The owner's signature
+   */
+  function permitTakeFromCaller(
+    address _token,
+    uint256 _amount,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes calldata _signature
+  ) external payable {
+    PERMIT2.takeFromCaller(_token, _amount, _nonce, _deadline, _signature);
+  }
+
+  /**
+   * @notice Takes the a batch of tokens from the caller with Permit2 and transfers it to this contract
+   * @param _tokens The tokens to take
+   * @param _nonce The signed nonce
+   * @param _deadline The signature's deadline
+   * @param _signature The owner's signature
+   */
+  function batchPermitTakeFromCaller(
+    IPermit2.TokenPermissions[] calldata _tokens,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes calldata _signature
+  ) external payable {
+    PERMIT2.batchTakeFromCaller(_tokens, _nonce, _deadline, _signature);
   }
 
   /**

--- a/contracts/utils/BaseCompanion.sol
+++ b/contracts/utils/BaseCompanion.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
-import '@mean-finance/swappers/solidity/contracts/extensions/GetBalances.sol';
 import '@mean-finance/swappers/solidity/contracts/extensions/RevokableWithGovernor.sol';
-import '@mean-finance/swappers/solidity/contracts/extensions/RunSwap.sol';
 import '@mean-finance/swappers/solidity/contracts/extensions/PayableMulticall.sol';
+import {SimulationAdapter} from '@mean-finance/call-simulation/contracts/SimulationAdapter.sol';
 import {IPermit2} from '../interfaces/external/IPermit2.sol';
 import {Permit2Transfers} from '../libraries/Permit2Transfers.sol';
 
@@ -13,8 +12,15 @@ import {Permit2Transfers} from '../libraries/Permit2Transfers.sol';
  *         contracts so that they can execute multicalls, swaps, revokes and more
  * @dev All public functions are payable, so that they can be multicalled together with other payable functions when msg.value > 0
  */
-abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, PayableMulticall {
+abstract contract BaseCompanion is SimulationAdapter, RevokableWithGovernor, PayableMulticall {
   using Permit2Transfers for IPermit2;
+
+  /**
+   * @notice Thrown when the swap produced less token out than expected
+   * @param received The amount of token out received
+   * @param expected The amount of token out expected
+   */
+  error ReceivedTooLittleTokenOut(uint256 received, uint256 expected);
 
   /**
    * @notice Returns the address of the Permit2 contract
@@ -24,11 +30,20 @@ abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, 
   // solhint-disable-next-line var-name-mixedcase
   IPermit2 public immutable PERMIT2;
 
+  /// @notice The address of the swapper
+  address public swapper;
+
+  /// @notice The address of the allowance target
+  address public allowanceTarget;
+
   constructor(
-    address _swapperRegistry,
+    address _swapper,
+    address _allowanceTarget,
     address _governor,
     IPermit2 _permit2
-  ) SwapAdapter(_swapperRegistry) Governable(_governor) {
+  ) SwapAdapter(address(1)) Governable(_governor) {
+    swapper = _swapper;
+    allowanceTarget = _allowanceTarget;
     PERMIT2 = _permit2;
   }
 
@@ -56,21 +71,48 @@ abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, 
   }
 
   /**
+   * @notice Executes a swap against the swapper
+   * @param _allowanceToken The token to set allowance for (can be set to zero address to ignore)
+   * @param _value The value to send to the swapper as part of the swap
+   * @param _swapData The swap data
+   * @param _tokenOut The token that will be bought as part of the swap
+   * @param _minTokenOut The min amount of token out that we expect
+   */
+  function runSwap(
+    address _allowanceToken,
+    uint256 _value,
+    bytes calldata _swapData,
+    address _tokenOut,
+    uint256 _minTokenOut
+  ) external payable returns (uint256 _amountOut) {
+    if (_allowanceToken != address(0)) {
+      IERC20(_allowanceToken).approve(allowanceTarget, type(uint256).max);
+    }
+
+    _executeSwap(swapper, _swapData, _value);
+
+    _amountOut = _tokenOut == PROTOCOL_TOKEN ? address(this).balance : IERC20(_tokenOut).balanceOf(address(this));
+    if (_amountOut < _minTokenOut) revert ReceivedTooLittleTokenOut(_amountOut, _minTokenOut);
+  }
+
+  /**
    * @notice Takes the given amount of tokens from the caller with Permit2 and transfers it to this contract
    * @param _token The token to take
    * @param _amount The amount to take
    * @param _nonce The signed nonce
    * @param _deadline The signature's deadline
    * @param _signature The owner's signature
+   * @param _recipient The address that will receive the funds
    */
   function permitTakeFromCaller(
     address _token,
     uint256 _amount,
     uint256 _nonce,
     uint256 _deadline,
-    bytes calldata _signature
+    bytes calldata _signature,
+    address _recipient
   ) external payable {
-    PERMIT2.takeFromCaller(_token, _amount, _nonce, _deadline, _signature);
+    PERMIT2.takeFromCaller(_token, _amount, _nonce, _deadline, _signature, _recipient);
   }
 
   /**
@@ -79,14 +121,16 @@ abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, 
    * @param _nonce The signed nonce
    * @param _deadline The signature's deadline
    * @param _signature The owner's signature
+   * @param _recipient The address that will receive the funds
    */
   function batchPermitTakeFromCaller(
     IPermit2.TokenPermissions[] calldata _tokens,
     uint256 _nonce,
     uint256 _deadline,
-    bytes calldata _signature
+    bytes calldata _signature,
+    address _recipient
   ) external payable {
-    PERMIT2.batchTakeFromCaller(_tokens, _nonce, _deadline, _signature);
+    PERMIT2.batchTakeFromCaller(_tokens, _nonce, _deadline, _signature, _recipient);
   }
 
   /**
@@ -97,5 +141,15 @@ abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, 
    */
   function sendBalanceOnContractToRecipient(address _token, address _recipient) external payable {
     _sendBalanceOnContractToRecipient(_token, _recipient);
+  }
+
+  /**
+   * @notice Sets a new swapper and allowance target
+   * @param _newSwapper The address of the new swapper
+   * @param _newAllowanceTarget The address of the new allowance target
+   */
+  function setSwapper(address _newSwapper, address _newAllowanceTarget) external onlyGovernor {
+    swapper = _newSwapper;
+    allowanceTarget = _newAllowanceTarget;
   }
 }

--- a/contracts/utils/BaseCompanion.sol
+++ b/contracts/utils/BaseCompanion.sol
@@ -21,6 +21,7 @@ abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, 
    * @dev This value is constant and cannot change
    * @return The address of the Permit2 contract
    */
+  // solhint-disable-next-line func-name-mixedcase
   IPermit2 public immutable PERMIT2;
 
   constructor(

--- a/contracts/utils/BaseCompanion.sol
+++ b/contracts/utils/BaseCompanion.sol
@@ -21,7 +21,7 @@ abstract contract BaseCompanion is RunSwap, RevokableWithGovernor, GetBalances, 
    * @dev This value is constant and cannot change
    * @return The address of the Permit2 contract
    */
-  // solhint-disable-next-line func-name-mixedcase
+  // solhint-disable-next-line var-name-mixedcase
   IPermit2 public immutable PERMIT2;
 
   constructor(

--- a/deploy/001_companion.ts
+++ b/deploy/001_companion.ts
@@ -7,7 +7,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
   const { deployer, msig } = await hre.getNamedAccounts();
 
   const permit2 = '0x000000000022d473030f116ddee9f6b43ac78ba3';
-  const swapperRegistry = await hre.deployments.get('SwapperRegistry');
+  const swapper = '0x8546189def9f233b61d7e72863da27f28b9986d7';
 
   await deployThroughDeterministicFactory({
     deployer,
@@ -16,8 +16,8 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     contract: 'contracts/DCAHubCompanion/DCAHubCompanion.sol:DCAHubCompanion',
     bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address'],
-      values: [swapperRegistry.address, msig, permit2],
+      types: ['address', 'address', 'address', 'address'],
+      values: [swapper, swapper, msig, permit2],
     },
     log: !process.env.TEST,
     overrides: !!process.env.COVERAGE

--- a/deploy/001_companion.ts
+++ b/deploy/001_companion.ts
@@ -6,17 +6,18 @@ import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-f
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, msig } = await hre.getNamedAccounts();
 
+  const permit2 = '0x000000000022d473030f116ddee9f6b43ac78ba3';
   const swapperRegistry = await hre.deployments.get('SwapperRegistry');
 
   await deployThroughDeterministicFactory({
     deployer,
     name: 'DCAHubCompanion',
-    salt: 'MF-DCAV2-DCAHubCompanion-V2',
+    salt: 'MF-DCAV2-DCAHubCompanion-V3',
     contract: 'contracts/DCAHubCompanion/DCAHubCompanion.sol:DCAHubCompanion',
     bytecode,
     constructorArgs: {
-      types: ['address', 'address'],
-      values: [swapperRegistry.address, msig],
+      types: ['address', 'address', 'address'],
+      values: [swapperRegistry.address, msig, permit2],
     },
     log: !process.env.TEST,
     overrides: !!process.env.COVERAGE

--- a/deploy/004_fee_manager.ts
+++ b/deploy/004_fee_manager.ts
@@ -6,17 +6,15 @@ import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-f
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, msig } = await hre.getNamedAccounts();
 
-  const swapperRegistry = await hre.deployments.get('SwapperRegistry');
-
   await deployThroughDeterministicFactory({
     deployer,
     name: 'DCAFeeManager',
-    salt: 'MF-DCAV2-DCAFeeManager-V2',
+    salt: 'MF-DCAV2-DCAFeeManager-V3',
     contract: 'contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager',
     bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address[]'],
-      values: [swapperRegistry.address, msig, [msig]],
+      types: ['address', 'address[]'],
+      values: [msig, [msig]],
     },
     log: !process.env.TEST,
     overrides: !!process.env.COVERAGE

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@0xged/hardhat-deploy": "0.11.5",
+    "@mean-finance/call-simulation": "^0.0.1",
     "@mean-finance/dca-v2-core": "3.3.0",
     "@mean-finance/deterministic-factory": "1.6.0",
     "@mean-finance/swappers": "1.1.0",
@@ -73,7 +74,7 @@
     "@commitlint/cli": "16.2.4",
     "@commitlint/config-conventional": "16.2.4",
     "@defi-wonderland/smock": "2.2.0",
-    "@mean-finance/sdk": "^0.0.118",
+    "@mean-finance/sdk": "0.0.119",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@0.3.0-beta.13",
     "@nomiclabs/hardhat-etherscan": "3.1.0",
     "@nomiclabs/hardhat-waffle": "2.0.3",

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -161,12 +161,12 @@ contract('DCAFeeManager', () => {
       [{ underlying: await transformerRegistry.PROTOCOL_TOKEN(), amount: total }],
       constants.MAX_UINT_256
     );
-    const { data: unwrapData } = await DCAFeeManager.populateTransaction.runSwap({
-      swapper: transformerRegistry.address,
-      allowanceTarget: transformerRegistry.address,
-      swapData: unwrapExecutionData!,
-      tokenIn: WETH.address,
-      amountIn: total,
+    const { data: unwrapData } = await DCAFeeManager.populateTransaction.runSwapsAndTransferMany({
+      allowanceTargets: [{ token: WETH.address, allowanceTarget: transformerRegistry.address, minAllowance: total }],
+      swappers: [transformerRegistry.address],
+      swaps: [unwrapExecutionData!],
+      swapContext: [{ swapperIndex: 0, value: 0 }],
+      transferOutBalance: [],
     });
     const { data: withdrawProtocolTokenData } = await DCAFeeManager.populateTransaction.withdrawFromBalance(
       [{ token: await DCAFeeManager.PROTOCOL_TOKEN(), amount: total }],

--- a/test/integration/DCAHubCompanion/multi-call.spec.ts
+++ b/test/integration/DCAHubCompanion/multi-call.spec.ts
@@ -7,7 +7,6 @@ import evm, { snapshot } from '@test-utils/evm';
 import { DCAHubCompanion, CallerOnlyDCAHubSwapper, IERC20 } from '@typechained';
 import { DCAHub, DCAPermissionsManager } from '@mean-finance/dca-v2-core';
 import { TransformerRegistry } from '@mean-finance/transformers';
-import { SwapperRegistry } from '@mean-finance/swappers';
 import { TransformerOracle, StatefulChainlinkOracle } from '@mean-finance/oracles';
 import { abi as DCA_HUB_ABI } from '@mean-finance/dca-v2-core/artifacts/contracts/DCAHub/DCAHub.sol/DCAHub.json';
 import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
@@ -36,7 +35,7 @@ contract('Multicall', () => {
   let DCAHubCompanion: DCAHubCompanion;
   let DCAPermissionManager: DCAPermissionsManager;
   let DCAHub: DCAHub;
-  let swapperRegistry: SwapperRegistry;
+  let companionSwapper: string;
   let DCAHubSwapper: CallerOnlyDCAHubSwapper;
   let transformerRegistry: TransformerRegistry;
   let permit2Address: string;
@@ -57,10 +56,10 @@ contract('Multicall', () => {
     DCAPermissionManager = await ethers.getContract('PermissionsManager');
     transformerRegistry = await ethers.getContract('TransformerRegistry');
 
-    swapperRegistry = await ethers.getContract<SwapperRegistry>('SwapperRegistry');
     const transformerOracle = await ethers.getContract<TransformerOracle>('TransformerOracle');
     const protocolTokenTransformer = await ethers.getContract('ProtocolTokenWrapperTransformer');
     const chainlinkOracle = await ethers.getContract<StatefulChainlinkOracle>('StatefulChainlinkOracle');
+    companionSwapper = await DCAHubCompanion.swapper();
 
     WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
     USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);
@@ -83,7 +82,6 @@ contract('Multicall', () => {
     permit2Address = await DCAHubCompanion.PERMIT2();
     await USDC.connect(positionOwner).approve(permit2Address, constants.MAX_UINT_256);
 
-    await swapperRegistry.connect(admin).allowSwappers([transformerRegistry.address]);
     await transformerRegistry
       .connect(admin)
       .registerTransformers([{ transformer: protocolTokenTransformer.address, dependents: [WETH.address] }]);
@@ -114,7 +112,7 @@ contract('Multicall', () => {
           let minExpected: BigNumber;
           given(async () => {
             const takeData = await permitTakeFromCallerDataIfUSDC({ from, amount: USDC_1000 });
-            const { swapExecutionData, expectedAmountOut } = await runSwapData({ tokenIn: await getAddress(from), amountIn: AMOUNT_IN, swap });
+            const { swapExecutionData, expectedAmountOut } = await runSwapData({ amountIn: AMOUNT_IN, swap });
             const depositData = await depositAllInCompanionData({ from: WETH, to: WBTC });
             await DCAHubCompanion.multicall(filterMulticalls([takeData, swapExecutionData, depositData]), {
               value: from === 'ETH' ? AMOUNT_IN : 0,
@@ -149,7 +147,7 @@ contract('Multicall', () => {
           given(async () => {
             const { positionId: createdPositionId, unswappedBalance } = await depositAndSwap({ from: WETH, to: USDC, amount: ETH_1 });
             const takeData = await permitTakeFromCallerDataIfUSDC({ from, amount: USDC_1000 });
-            const { swapExecutionData, expectedAmountOut } = await runSwapData({ tokenIn: await getAddress(from), amountIn: AMOUNT_IN, swap });
+            const { swapExecutionData, expectedAmountOut } = await runSwapData({ amountIn: AMOUNT_IN, swap });
             const permissionData = await givePermissionToCompanionData({
               signer: positionOwner,
               positionId: createdPositionId,
@@ -194,8 +192,8 @@ contract('Multicall', () => {
               positionId,
               permissions: [Permission.WITHDRAW],
             });
-            const withdrawData = await withdrawSwappedData({ positionId, recipient: DCAHubCompanion });
-            const { swapExecutionData, expectedAmountOut } = await runSwapData({ tokenIn: WETH.address, amountIn: swappedBalance, swap });
+            const withdrawData = await withdrawSwappedData({ positionId, recipient: companionSwapper });
+            const { swapExecutionData, expectedAmountOut } = await runSwapData({ amountIn: swappedBalance, swap });
             const sendData = await sendAllInCompanionToRecipientData({ token: await getAddress(to), recipient });
             await DCAHubCompanion.multicall([permissionData, withdrawData, swapExecutionData, sendData]);
             minExpected = expectedAmountOut;
@@ -231,8 +229,8 @@ contract('Multicall', () => {
           given(async () => {
             const { positionId, unswappedBalance } = await depositAndSwap({ from: WETH, to: USDC, amount: ETH_1 });
             const permissionData = await givePermissionToCompanionData({ signer: positionOwner, positionId, permissions: [Permission.REDUCE] });
-            const reduceData = await reduceAllPositionData({ positionId, recipient: DCAHubCompanion });
-            const { swapExecutionData, expectedAmountOut } = await runSwapData({ tokenIn: WETH.address, amountIn: unswappedBalance, swap });
+            const reduceData = await reduceAllPositionData({ positionId, recipient: companionSwapper });
+            const { swapExecutionData, expectedAmountOut } = await runSwapData({ amountIn: unswappedBalance, swap });
             const sendData = await sendAllInCompanionToRecipientData({ token: await getAddress(to), recipient });
             await DCAHubCompanion.multicall([permissionData, reduceData, swapExecutionData, sendData]);
             minExpected = expectedAmountOut;
@@ -259,20 +257,18 @@ contract('Multicall', () => {
         given(async () => {
           const { positionId, swappedBalance, unswappedBalance } = await depositAndSwap({ from: WETH, to: USDC, amount: ETH_1 });
           const permissionData = await givePermissionToCompanionData({ signer: positionOwner, positionId, permissions: [Permission.TERMINATE] });
-          const terminateData = await terminateAndSendToCompanionData({ positionId });
+          const _terminateData = await terminateData({ positionId, recipient: companionSwapper });
           const { swapExecutionData: executionDataETH, expectedAmountOut: _expectedAmountOutETH } = await runSwapData({
-            tokenIn: WETH.address,
             amountIn: unswappedBalance,
             swap: ({ amountIn }) => transformWETHToETH(amountIn),
           });
           const { swapExecutionData: executionDataWBTC, expectedAmountOut: _expectedAmountOutBTC } = await runSwapData({
-            tokenIn: USDC.address,
             amountIn: swappedBalance,
             swap: ({ amountIn }) => swapInDex({ from: USDC, to: WBTC, amountIn }),
           });
           const sendETHData = await sendAllInCompanionToRecipientData({ token: await DCAHubCompanion.PROTOCOL_TOKEN(), recipient });
           const sendWBTCData = await sendAllERC20InCompanionToRecipientData({ token: WBTC, recipient });
-          await DCAHubCompanion.multicall([permissionData, terminateData, executionDataETH, sendETHData, executionDataWBTC, sendWBTCData]);
+          await DCAHubCompanion.multicall([permissionData, _terminateData, executionDataETH, sendETHData, executionDataWBTC, sendWBTCData]);
           expectedAmountOutETH = _expectedAmountOutETH;
           expectedAmountOutBTC = _expectedAmountOutBTC;
         });
@@ -618,39 +614,59 @@ contract('Multicall', () => {
     return data!;
   }
 
-  type Swap = (_: {
-    amountIn: BigNumber;
-  }) => Promise<{ swapper: string; allowanceTarget: string; swapData: BytesLike; expectedAmountOut: BigNumber }>;
-  async function runSwapData({ tokenIn, amountIn, swap }: { tokenIn: string; amountIn: BigNumber; swap: Swap }) {
-    const { swapper, swapData, expectedAmountOut, allowanceTarget } = await swap({ amountIn });
-    const { data } = await DCAHubCompanion.populateTransaction.runSwap({
-      swapper,
-      allowanceTarget,
-      swapData,
-      tokenIn,
-      amountIn,
+  type Swap = (_: { amountIn: BigNumber }) => Promise<{
+    tokenIn: string;
+    tokenOut: string;
+    swapper: string;
+    allowanceTarget: string;
+    swapData: string;
+    expectedAmountOut: BigNumber;
+    value?: BigNumber;
+  }>;
+  async function runSwapData({ amountIn, swap }: { amountIn: BigNumber; swap: Swap }) {
+    const { tokenIn, tokenOut, swapper, swapData, expectedAmountOut, allowanceTarget, value } = await swap({ amountIn });
+    const allowanceTargets = isSameAddress(allowanceTarget, constants.ZERO_ADDRESS) ? [] : [{ token: tokenIn, target: allowanceTarget }];
+    const tokenOutDistribution = isSameAddress(tokenOut, await DCAHubCompanion.PROTOCOL_TOKEN()) ? constants.ZERO_ADDRESS : tokenOut;
+
+    const arbitraryCall = buildSDK().permit2Service.arbitrary.buildArbitraryCallWithoutPermit({
+      allowanceTargets,
+      calls: [{ to: swapper, data: swapData, value: value?.toBigInt() ?? 0 }],
+      distribution: { [tokenOutDistribution]: [{ recipient: DCAHubCompanion.address, shareBps: 0 }] },
+      txValidFor: '1y',
     });
+    const { data } = await DCAHubCompanion.populateTransaction.runSwap(
+      constants.ZERO_ADDRESS, // No need to set it because we are already transferring the funds to the swapper
+      value?.toBigInt() ?? 0,
+      arbitraryCall.data,
+      tokenOut,
+      expectedAmountOut
+    );
     return { swapExecutionData: data!, expectedAmountOut };
   }
 
-  async function withdrawSwappedData({ positionId, recipient }: { positionId: BigNumberish; recipient: HasAddress }) {
-    const { data } = await DCAHubCompanion.populateTransaction.withdrawSwapped(DCAHub.address, positionId, recipient.address);
-    return data!;
-  }
-
-  async function reduceAllPositionData({ positionId, recipient }: { positionId: BigNumberish; recipient: HasAddress }) {
-    const { remaining } = await DCAHub.userPosition(positionId);
-    const { data } = await DCAHubCompanion.populateTransaction.reducePosition(DCAHub.address, positionId, remaining, 0, recipient.address);
-    return data!;
-  }
-
-  async function terminateAndSendToCompanionData({ positionId }: { positionId: BigNumberish }) {
-    const { data } = await DCAHubCompanion.populateTransaction.terminate(
+  async function withdrawSwappedData({ positionId, recipient }: { positionId: BigNumberish; recipient: HasAddress | string }) {
+    const { data } = await DCAHubCompanion.populateTransaction.withdrawSwapped(
       DCAHub.address,
       positionId,
-      DCAHubCompanion.address,
-      DCAHubCompanion.address
+      typeof recipient === 'string' ? recipient : recipient.address
     );
+    return data!;
+  }
+
+  async function reduceAllPositionData({ positionId, recipient }: { positionId: BigNumberish; recipient: HasAddress | string }) {
+    const { remaining } = await DCAHub.userPosition(positionId);
+    const { data } = await DCAHubCompanion.populateTransaction.reducePosition(
+      DCAHub.address,
+      positionId,
+      remaining,
+      0,
+      typeof recipient === 'string' ? recipient : recipient.address
+    );
+    return data!;
+  }
+
+  async function terminateData({ positionId, recipient }: { positionId: BigNumberish; recipient: string }) {
+    const { data } = await DCAHubCompanion.populateTransaction.terminate(DCAHub.address, positionId, recipient, recipient);
     return data!;
   }
 
@@ -706,7 +722,14 @@ contract('Multicall', () => {
     deadline: BigNumberish;
     signature: string;
   }) {
-    const { data } = await DCAHubCompanion.populateTransaction.permitTakeFromCaller(token.address, amount, nonce, deadline, signature);
+    const { data } = await DCAHubCompanion.populateTransaction.permitTakeFromCaller(
+      token.address,
+      amount,
+      nonce,
+      deadline,
+      signature,
+      companionSwapper
+    );
     return data!;
   }
 
@@ -725,11 +748,12 @@ contract('Multicall', () => {
   }
 
   async function transformWETHToETH(amount: BigNumber) {
+    const nativeToken = await DCAHubCompanion.PROTOCOL_TOKEN();
     const { data } = await transformerRegistry.populateTransaction.transformToUnderlying(
       WETH.address,
       amount,
       DCAHubCompanion.address,
-      [{ underlying: await DCAHubCompanion.PROTOCOL_TOKEN(), amount }],
+      [{ underlying: nativeToken, amount }],
       constants.MAX_UINT_256
     );
     return {
@@ -737,13 +761,16 @@ contract('Multicall', () => {
       swapper: transformerRegistry.address,
       expectedAmountOut: amount,
       allowanceTarget: transformerRegistry.address,
+      tokenIn: WETH.address,
+      tokenOut: nativeToken,
     };
   }
 
   async function transformETHToWETH(amount: BigNumber) {
+    const nativeToken = await DCAHubCompanion.PROTOCOL_TOKEN();
     const { data } = await transformerRegistry.populateTransaction.transformToDependent(
       WETH.address,
-      [{ underlying: await DCAHubCompanion.PROTOCOL_TOKEN(), amount }],
+      [{ underlying: nativeToken, amount }],
       DCAHubCompanion.address,
       amount,
       constants.MAX_UINT_256
@@ -753,41 +780,40 @@ contract('Multicall', () => {
       swapper: transformerRegistry.address,
       expectedAmountOut: amount,
       allowanceTarget: constants.ZERO_ADDRESS,
+      tokenIn: nativeToken,
+      tokenOut: WETH.address,
+      value: amount,
     };
   }
 
   async function swapInDex({ from, to, amountIn }: { from: IERC20; to: IERC20; amountIn: BigNumber }) {
     const { quoteService } = buildSDK();
-    const quotes = await quoteService.getAllQuotes({
+    const {
+      tx,
+      minBuyAmount,
+      source: { allowanceTarget },
+    } = await quoteService.getBestQuote({
       request: {
         chainId: 1,
         sellToken: from.address,
         buyToken: to.address,
         order: { type: 'sell', sellAmount: amountIn.toString() },
         slippagePercentage: 5, // 5%
-        takerAddress: DCAHubCompanion.address,
-        filters: { includeSources: ['1inch', 'paraswap'] },
+        takerAddress: companionSwapper,
+        filters: { includeSources: ['1inch', 'paraswap', 'open-ocean', 'li-fi'] },
       },
       config: {
         timeout: '3s',
-        ignoredFailed: true,
-        sort: { by: 'most-swapped', using: 'max sell/min buy amounts' },
+        choose: { by: 'most-swapped', using: 'max sell/min buy amounts' },
       },
     });
-    const {
-      tx,
-      minBuyAmount,
-      source: { allowanceTarget },
-    } = quotes[0];
-    await swapperRegistry.connect(admin).allowSwappers([tx.to]);
-    if (!isSameAddress(tx.to, allowanceTarget)) {
-      await swapperRegistry.connect(admin).allowSupplementaryAllowanceTargets([allowanceTarget]);
-    }
     return {
       swapData: tx.data,
       swapper: tx.to,
       expectedAmountOut: BigNumber.from(minBuyAmount.amount),
       allowanceTarget,
+      tokenIn: from.address,
+      tokenOut: to.address,
     };
   }
 

--- a/test/unit/utils/base-companion.spec.ts
+++ b/test/unit/utils/base-companion.spec.ts
@@ -2,9 +2,10 @@ import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { contract, given, then, when } from '@test-utils/bdd';
 import { snapshot } from '@test-utils/evm';
-import { BaseCompanionMock, BaseCompanionMock__factory, IERC20, IPermit2 } from '@typechained';
+import behaviors from '@test-utils/behaviours';
+import { BaseCompanionMock, BaseCompanionMock__factory, IERC20, IPermit2, ISwapper } from '@typechained';
 import { FakeContract, smock } from '@defi-wonderland/smock';
-import { Wallet } from 'ethers';
+import { BytesLike, Wallet, constants } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 chai.use(smock.matchers);
@@ -14,8 +15,9 @@ contract('BaseCompanion', () => {
   const RECIPIENT = Wallet.createRandom();
   let token: FakeContract<IERC20>;
   let permit2: FakeContract<IPermit2>;
+  let swapper: FakeContract<ISwapper>;
   let baseCompanion: BaseCompanionMock;
-  let caller: SignerWithAddress;
+  let caller: SignerWithAddress, governor: SignerWithAddress;
   let snapshotId: string;
 
   before('Setup accounts and contracts', async () => {
@@ -23,14 +25,17 @@ contract('BaseCompanion', () => {
     const registry = await smock.fake('ISwapperRegistry');
     token = await smock.fake('IERC20');
     permit2 = await smock.fake('IPermit2');
-    [caller] = await ethers.getSigners();
-    baseCompanion = await baseCompanionFactory.deploy(registry.address, RECIPIENT.address, permit2.address);
+    swapper = await smock.fake('ISwapper');
+    [caller, governor] = await ethers.getSigners();
+    baseCompanion = await baseCompanionFactory.deploy(swapper.address, swapper.address, governor.address, permit2.address);
     snapshotId = await snapshot.take();
   });
 
   beforeEach(async () => {
     await snapshot.revert(snapshotId);
     token.transfer.reset();
+    token.balanceOf.reset();
+    token.approve.reset();
     token.transferFrom.returns(true);
     token.transfer.returns(true);
   });
@@ -65,6 +70,42 @@ contract('BaseCompanion', () => {
     });
   });
 
+  describe('runSwap', () => {
+    let swapExecution: BytesLike;
+    given(async () => {
+      const { data } = await swapper.populateTransaction.swap(token.address, 1000, token.address);
+      swapExecution = data!;
+    });
+    when('swap is executed', () => {
+      given(async () => {
+        await baseCompanion.runSwap(token.address, 0, swapExecution, token.address, 0);
+      });
+      then('max approval is given', () => {
+        expect(token.approve).to.have.been.calledOnceWith(swapper.address, constants.MaxUint256);
+      });
+      then('swapper is called correctly', () => {
+        expect(swapper.swap).to.have.been.calledWith(token.address, 1000, token.address);
+      });
+      then('balance is checked correctly', () => {
+        expect(token.balanceOf).to.have.been.calledOnceWith(baseCompanion.address);
+      });
+    });
+    when('allowance token is not set', () => {
+      given(async () => {
+        await baseCompanion.runSwap(constants.AddressZero, 0, swapExecution, token.address, 0);
+      });
+      then('approve is not called', () => {
+        expect(token.approve).to.not.have.been.called;
+      });
+    });
+    when('returned balance is less than expected', () => {
+      then('call reverts', async () => {
+        const tx = baseCompanion.runSwap(constants.AddressZero, 0, swapExecution, token.address, 1);
+        expect(tx).to.have.revertedWith('ReceivedTooLittleTokenOut(0,1)');
+      });
+    });
+  });
+
   describe('sendBalanceOnContractToRecipient', () => {
     when('sending balance on contract to a recipient', () => {
       given(async () => {
@@ -82,7 +123,7 @@ contract('BaseCompanion', () => {
   describe('permitTakeFromCaller', () => {
     when('taking from caller with permit', () => {
       given(async () => {
-        await baseCompanion.permitTakeFromCaller(token.address, 12345, 678910, 2468, '0x1234');
+        await baseCompanion.permitTakeFromCaller(token.address, 12345, 678910, 2468, '0x1234', swapper.address);
       });
       then('internal function is called correctly', async () => {
         expect(permit2['permitTransferFrom(((address,uint256),uint256,uint256),(address,uint256),address,bytes)']).to.have.been.calledOnce;
@@ -93,7 +134,7 @@ contract('BaseCompanion', () => {
         expect(permit.permitted.amount).to.equal(12345);
         expect(permit.nonce).to.equal(678910);
         expect(permit.deadline).to.equal(2468);
-        expect(transferDetails.to).to.equal(baseCompanion.address);
+        expect(transferDetails.to).to.equal(swapper.address);
         expect(transferDetails.requestedAmount).to.equal(12345);
         expect(owner).to.equal(caller.address);
         expect(signature).to.equal('0x1234');
@@ -104,7 +145,7 @@ contract('BaseCompanion', () => {
   describe('batchPermitTakeFromCaller', () => {
     when('taking from caller with permit', () => {
       given(async () => {
-        await baseCompanion.batchPermitTakeFromCaller([{ token: token.address, amount: 12345 }], 678910, 2468, '0x1234');
+        await baseCompanion.batchPermitTakeFromCaller([{ token: token.address, amount: 12345 }], 678910, 2468, '0x1234', swapper.address);
       });
       then('internal function is called correctly', async () => {
         expect(permit2['permitTransferFrom(((address,uint256)[],uint256,uint256),(address,uint256)[],address,bytes)']).to.have.been.calledOnce;
@@ -117,11 +158,31 @@ contract('BaseCompanion', () => {
         expect(permit.nonce).to.equal(678910);
         expect(permit.deadline).to.equal(2468);
         expect(transferDetails).to.have.lengthOf(1);
-        expect(transferDetails[0].to).to.equal(baseCompanion.address);
+        expect(transferDetails[0].to).to.equal(swapper.address);
         expect(transferDetails[0].requestedAmount).to.equal(12345);
         expect(owner).to.equal(caller.address);
         expect(signature).to.equal('0x1234');
       });
+    });
+  });
+
+  describe('setSwapper', () => {
+    const newSwapper = '0x0000000000000000000000000000000000000001';
+    const newAllowanceTarget = '0x0000000000000000000000000000000000000002';
+    when('setting a new swapper', () => {
+      given(async () => {
+        await baseCompanion.connect(governor).setSwapper(newSwapper, newAllowanceTarget);
+      });
+      then('it is set correctly', async () => {
+        expect(await baseCompanion.swapper()).to.equal(newSwapper);
+        expect(await baseCompanion.allowanceTarget()).to.equal(newAllowanceTarget);
+      });
+    });
+    behaviors.shouldBeExecutableOnlyByGovernor({
+      contract: () => baseCompanion,
+      funcAndSignature: 'setSwapper',
+      params: [newSwapper, newSwapper],
+      governor: () => governor,
     });
   });
 });

--- a/test/unit/utils/base-companion.spec.ts
+++ b/test/unit/utils/base-companion.spec.ts
@@ -2,9 +2,10 @@ import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { contract, given, then, when } from '@test-utils/bdd';
 import { snapshot } from '@test-utils/evm';
-import { BaseCompanionMock, BaseCompanionMock__factory, IERC20 } from '@typechained';
+import { BaseCompanionMock, BaseCompanionMock__factory, IERC20, IPermit2 } from '@typechained';
 import { FakeContract, smock } from '@defi-wonderland/smock';
 import { Wallet } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 chai.use(smock.matchers);
 
@@ -12,14 +13,18 @@ contract('BaseCompanion', () => {
   const AMOUNT = 123456789;
   const RECIPIENT = Wallet.createRandom();
   let token: FakeContract<IERC20>;
+  let permit2: FakeContract<IPermit2>;
   let baseCompanion: BaseCompanionMock;
+  let caller: SignerWithAddress;
   let snapshotId: string;
 
   before('Setup accounts and contracts', async () => {
     const baseCompanionFactory: BaseCompanionMock__factory = await ethers.getContractFactory('BaseCompanionMock');
     const registry = await smock.fake('ISwapperRegistry');
     token = await smock.fake('IERC20');
-    baseCompanion = await baseCompanionFactory.deploy(registry.address, RECIPIENT.address);
+    permit2 = await smock.fake('IPermit2');
+    [caller] = await ethers.getSigners();
+    baseCompanion = await baseCompanionFactory.deploy(registry.address, RECIPIENT.address, permit2.address);
     snapshotId = await snapshot.take();
   });
 
@@ -70,6 +75,52 @@ contract('BaseCompanion', () => {
         expect(calls).to.have.lengthOf(1);
         expect(calls[0].token).to.equal(token.address);
         expect(calls[0].recipient).to.equal(RECIPIENT.address);
+      });
+    });
+  });
+
+  describe('permitTakeFromCaller', () => {
+    when('taking from caller with permit', () => {
+      given(async () => {
+        await baseCompanion.permitTakeFromCaller(token.address, 12345, 678910, 2468, '0x1234');
+      });
+      then('internal function is called correctly', async () => {
+        expect(permit2['permitTransferFrom(((address,uint256),uint256,uint256),(address,uint256),address,bytes)']).to.have.been.calledOnce;
+        const {
+          args: [permit, transferDetails, owner, signature],
+        } = permit2['permitTransferFrom(((address,uint256),uint256,uint256),(address,uint256),address,bytes)'].getCall(0) as { args: any[] };
+        expect(permit.permitted.token).to.equal(token.address);
+        expect(permit.permitted.amount).to.equal(12345);
+        expect(permit.nonce).to.equal(678910);
+        expect(permit.deadline).to.equal(2468);
+        expect(transferDetails.to).to.equal(baseCompanion.address);
+        expect(transferDetails.requestedAmount).to.equal(12345);
+        expect(owner).to.equal(caller.address);
+        expect(signature).to.equal('0x1234');
+      });
+    });
+  });
+
+  describe('batchPermitTakeFromCaller', () => {
+    when('taking from caller with permit', () => {
+      given(async () => {
+        await baseCompanion.batchPermitTakeFromCaller([{ token: token.address, amount: 12345 }], 678910, 2468, '0x1234');
+      });
+      then('internal function is called correctly', async () => {
+        expect(permit2['permitTransferFrom(((address,uint256)[],uint256,uint256),(address,uint256)[],address,bytes)']).to.have.been.calledOnce;
+        const {
+          args: [permit, transferDetails, owner, signature],
+        } = permit2['permitTransferFrom(((address,uint256)[],uint256,uint256),(address,uint256)[],address,bytes)'].getCall(0) as { args: any[] };
+        expect(permit.permitted).to.have.lengthOf(1);
+        expect(permit.permitted[0].token).to.equal(token.address);
+        expect(permit.permitted[0].amount).to.equal(12345);
+        expect(permit.nonce).to.equal(678910);
+        expect(permit.deadline).to.equal(2468);
+        expect(transferDetails).to.have.lengthOf(1);
+        expect(transferDetails[0].to).to.equal(baseCompanion.address);
+        expect(transferDetails[0].requestedAmount).to.equal(12345);
+        expect(owner).to.equal(caller.address);
+        expect(signature).to.equal('0x1234');
       });
     });
   });

--- a/test/utils/behaviours.ts
+++ b/test/utils/behaviours.ts
@@ -198,7 +198,7 @@ const shouldBeExecutableOnlyByGovernor = ({
         [funcAndSignature](...realParams!);
     });
     then('tx is reverted with reason', async () => {
-      await expect(onlyGovernorAllowedTx).to.be.revertedWith('Governable: only governor');
+      await expect(onlyGovernorAllowedTx).to.be.revertedWith('OnlyGovernor');
     });
   });
   when('called from governor', () => {
@@ -209,7 +209,7 @@ const shouldBeExecutableOnlyByGovernor = ({
         [funcAndSignature](...realParams!);
     });
     then('tx is not reverted or not reverted with reason only governor', async () => {
-      await expect(onlyGovernorAllowedTx).to.not.be.revertedWith('Governable: only governor');
+      await expect(onlyGovernorAllowedTx).to.not.be.revertedWith('OnlyGovernor');
     });
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,6 +1216,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@mean-finance/call-simulation@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@mean-finance/call-simulation/-/call-simulation-0.0.1.tgz#719acb89e736add8fbe09a08daa342459457cea5"
+  integrity sha512-WngN+1AqJAcEcP148SO84ENQfwFloZmKxA7CN8Dlk3J7fS+xaVX1j6QIXLiCouI4OkuKBw7JzeRfjzWmESTk7A==
+
 "@mean-finance/chainlink-registry@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@mean-finance/chainlink-registry/-/chainlink-registry-2.1.0.tgz#f11d78a617a9e0e9f2aec6b7b0f6fe2db07b86fe"
@@ -1278,10 +1283,10 @@
     "@uniswap/v3-core" "1.0.1"
     moment "2.29.3"
 
-"@mean-finance/sdk@^0.0.118":
-  version "0.0.118"
-  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.118.tgz#240b2ef7e8c5d81bda4c999e6ed37c5664c7d6e9"
-  integrity sha512-u/LIWrl+azwdQQVY2W9KqSu3wuyUCdUq8fgoqEGzBI1alNSKDOXivFATulgXWiYmtdNOPr0ZsOEULw44B5yhwA==
+"@mean-finance/sdk@0.0.119":
+  version "0.0.119"
+  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.119.tgz#81b8f04bc560d507df499a068000c3d2d11bd4e7"
+  integrity sha512-U4RR0Ex0DQtV+clkUgIPkbtTox3JDeBau+pP+bjlI/PPli1iNxkbtFY2kapMxaM266sreTNYMg3eS1RxllUdLg==
   dependencies:
     alchemy-sdk "2.9.0"
     cross-fetch "3.1.5"


### PR DESCRIPTION
We are now adding a way to take tokens from the caller by using Permit2, instead of the regular `approve` + `transferFrom`