### PR TITLE
refactor: remove swapper registry from fee manager

### DIFF
--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.7 <0.9.0;
 
 import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHub.sol';
-import '@mean-finance/swappers/solidity/contracts/extensions/RunSwap.sol';
 import '@mean-finance/swappers/solidity/contracts/extensions/TakeManyRunSwapsAndTransferMany.sol';
 
 /**
@@ -13,6 +12,20 @@ import '@mean-finance/swappers/solidity/contracts/extensions/TakeManyRunSwapsAnd
  *         of their choosing
  */
 interface IDCAFeeManager {
+  /// @notice The parameters to execute the call
+  struct RunSwapsAndTransferManyParams {
+    // The accounts that should be approved for spending
+    Allowance[] allowanceTargets;
+    // The different swappers involved in the swap
+    address[] swappers;
+    // The different swapps to execute
+    bytes[] swaps;
+    // Context necessary for the swap execution
+    SwapContext[] swapContext;
+    // Tokens to transfer after swaps have been executed
+    TransferOutBalance[] transferOutBalance;
+  }
+
   /// @notice Represents a share of a target token
   struct TargetTokenShare {
     address token;
@@ -69,22 +82,11 @@ interface IDCAFeeManager {
   function positions(bytes32 pairKey) external view returns (uint256); // key(from, to) => position id
 
   /**
-   * @notice Executes a swap with the given swapper. The input tokens are expected to be on the contract before
-   *         this function is executed. If the swap doesn't include a transfer, then the swapped tokens will be left
-   *         on the contract
-   * @dev This function can only be executed with swappers that are allowlisted. Can only be executed by admins
-   * @param parameters The parameters for the swap
-   */
-  function runSwap(RunSwap.RunSwapParams calldata parameters) external payable;
-
-  /**
    * @notice Executes multiple swaps
-   * @dev This function can only be executed with swappers that are allowlisted. Can only be executed by admins
+   * @dev Can only be executed by admins
    * @param parameters The parameters for the swap
    */
-  function takeManyRunSwapsAndTransferMany(TakeManyRunSwapsAndTransferMany.TakeManyRunSwapsAndTransferManyParams calldata parameters)
-    external
-    payable;
+  function runSwapsAndTransferMany(RunSwapsAndTransferManyParams calldata parameters) external payable;
 
   /**
    * @notice Withdraws tokens from the platform balance, and sends them to the given recipient

--- a/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/mocks/DCAFeeManager/DCAFeeManager.sol
@@ -19,11 +19,7 @@ contract DCAFeeManagerMock is DCAFeeManager {
   SendBalanceOnContractToRecipientCall[] internal _sendBalanceOnContractToRecipientCalls;
   RevokeAction[][] internal _revokeCalls;
 
-  constructor(
-    address _swapperRegistry,
-    address _superAdmin,
-    address[] memory _initialAdmins
-  ) DCAFeeManager(_swapperRegistry, _superAdmin, _initialAdmins) {}
+  constructor(address _superAdmin, address[] memory _initialAdmins) DCAFeeManager(_superAdmin, _initialAdmins) {}
 
   function sendBalanceOnContractToRecipientCalls() external view returns (SendBalanceOnContractToRecipientCall[] memory) {
     return _sendBalanceOnContractToRecipientCalls;

--- a/deploy/004_fee_manager.ts
+++ b/deploy/004_fee_manager.ts
@@ -6,17 +6,15 @@ import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-f
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, msig } = await hre.getNamedAccounts();
 
-  const swapperRegistry = await hre.deployments.get('SwapperRegistry');
-
   await deployThroughDeterministicFactory({
     deployer,
     name: 'DCAFeeManager',
-    salt: 'MF-DCAV2-DCAFeeManager-V2',
+    salt: 'MF-DCAV2-DCAFeeManager-V3',
     contract: 'contracts/DCAFeeManager/DCAFeeManager.sol:DCAFeeManager',
     bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address[]'],
-      values: [swapperRegistry.address, msig, [msig]],
+      types: ['address', 'address[]'],
+      values: [msig, [msig]],
     },
     log: !process.env.TEST,
     overrides: !!process.env.COVERAGE

--- a/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
+++ b/test/integration/DCAFeeManager/dca-fee-manager.spec.ts
@@ -161,12 +161,12 @@ contract('DCAFeeManager', () => {
       [{ underlying: await transformerRegistry.PROTOCOL_TOKEN(), amount: total }],
       constants.MAX_UINT_256
     );
-    const { data: unwrapData } = await DCAFeeManager.populateTransaction.runSwap({
-      swapper: transformerRegistry.address,
-      allowanceTarget: transformerRegistry.address,
-      swapData: unwrapExecutionData!,
-      tokenIn: WETH.address,
-      amountIn: total,
+    const { data: unwrapData } = await DCAFeeManager.populateTransaction.runSwapsAndTransferMany({
+      allowanceTargets: [{ token: WETH.address, allowanceTarget: transformerRegistry.address, minAllowance: total }],
+      swappers: [transformerRegistry.address],
+      swaps: [unwrapExecutionData!],
+      swapContext: [{ swapperIndex: 0, value: 0 }],
+      transferOutBalance: [],
     });
     const { data: withdrawProtocolTokenData } = await DCAFeeManager.populateTransaction.withdrawFromBalance(
       [{ token: await DCAFeeManager.PROTOCOL_TOKEN(), amount: total }],


### PR DESCRIPTION
We are now removing the Swapper Registry from the Fee Manager. Since all calls are permissioned, we don't need the registry. We are:
- Removing `runSwap`
- Chainging `takeManyRunSwapsAndTransferMany` to `runSwapsAndTransferMany`
  - This version does not take tokens from the caller
  - And does not use the swapper registry when checking for swappers or allowance targets
 