### PR TITLE
refactor: remove swap registry from companion

### DIFF
--- a/contracts/DCAHubCompanion/DCAHubCompanion.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanion.sol
@@ -7,8 +7,9 @@ import '../utils/BaseCompanion.sol';
 
 contract DCAHubCompanion is DCAHubCompanionLibrariesHandler, DCAHubCompanionHubProxyHandler, BaseCompanion, IDCAHubCompanion {
   constructor(
-    address _swapperRegistry,
+    address _swapper,
+    address _allowanceTarget,
     address _governor,
     IPermit2 _permit2
-  ) BaseCompanion(_swapperRegistry, _governor, _permit2) {}
+  ) BaseCompanion(_swapper, _allowanceTarget, _governor, _permit2) {}
 }

--- a/contracts/libraries/Permit2Transfers.sol
+++ b/contracts/libraries/Permit2Transfers.sol
@@ -17,6 +17,7 @@ library Permit2Transfers {
    * @param _nonce The owner's nonce
    * @param _deadline The signature's expiration deadline
    * @param _signature The signature that allows the transfer
+   * @param _recipient The address that will receive the funds
    */
   function takeFromCaller(
     IPermit2 _permit2,
@@ -24,13 +25,14 @@ library Permit2Transfers {
     uint256 _amount,
     uint256 _nonce,
     uint256 _deadline,
-    bytes calldata _signature
+    bytes calldata _signature,
+    address _recipient
   ) internal {
     _permit2.permitTransferFrom(
       // The permit message.
       IPermit2.PermitTransferFrom({permitted: IPermit2.TokenPermissions({token: _token, amount: _amount}), nonce: _nonce, deadline: _deadline}),
       // The transfer recipient and amount.
-      IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: _amount}),
+      IPermit2.SignatureTransferDetails({to: _recipient, requestedAmount: _amount}),
       // The owner of the tokens, which must also be
       // the signer of the message, otherwise this call
       // will fail.
@@ -48,20 +50,22 @@ library Permit2Transfers {
    * @param _nonce The owner's nonce
    * @param _deadline The signature's expiration deadline
    * @param _signature The signature that allows the transfer
+   * @param _recipient The address that will receive the funds
    */
   function batchTakeFromCaller(
     IPermit2 _permit2,
     IPermit2.TokenPermissions[] calldata _tokens,
     uint256 _nonce,
     uint256 _deadline,
-    bytes calldata _signature
+    bytes calldata _signature,
+    address _recipient
   ) internal {
     if (_tokens.length > 0) {
       _permit2.permitTransferFrom(
         // The permit message.
         IPermit2.PermitBatchTransferFrom({permitted: _tokens, nonce: _nonce, deadline: _deadline}),
         // The transfer recipients and amounts.
-        _buildTransferDetails(_tokens),
+        _buildTransferDetails(_tokens, _recipient),
         // The owner of the tokens, which must also be
         // the signer of the message, otherwise this call
         // will fail.
@@ -73,14 +77,14 @@ library Permit2Transfers {
     }
   }
 
-  function _buildTransferDetails(IPermit2.TokenPermissions[] calldata _tokens)
+  function _buildTransferDetails(IPermit2.TokenPermissions[] calldata _tokens, address _recipient)
     private
-    view
+    pure
     returns (IPermit2.SignatureTransferDetails[] memory _details)
   {
     _details = new IPermit2.SignatureTransferDetails[](_tokens.length);
     for (uint256 i; i < _details.length; ) {
-      _details[i] = IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: _tokens[i].amount});
+      _details[i] = IPermit2.SignatureTransferDetails({to: _recipient, requestedAmount: _tokens[i].amount});
       unchecked {
         ++i;
       }

--- a/contracts/mocks/utils/BaseCompanion.sol
+++ b/contracts/mocks/utils/BaseCompanion.sol
@@ -5,10 +5,11 @@ import '../../utils/BaseCompanion.sol';
 
 contract BaseCompanionMock is BaseCompanion {
   constructor(
-    address _swapperRegistry,
+    address _swapper,
+    address _allowanceTarget,
     address _governor,
     IPermit2 _permit2
-  ) BaseCompanion(_swapperRegistry, _governor, _permit2) {}
+  ) BaseCompanion(_swapper, _allowanceTarget, _governor, _permit2) {}
 
   struct TakeFromMsgSenderCall {
     IERC20 token;

--- a/deploy/001_companion.ts
+++ b/deploy/001_companion.ts
@@ -7,7 +7,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
   const { deployer, msig } = await hre.getNamedAccounts();
 
   const permit2 = '0x000000000022d473030f116ddee9f6b43ac78ba3';
-  const swapperRegistry = await hre.deployments.get('SwapperRegistry');
+  const swapper = '0x8546189def9f233b61d7e72863da27f28b9986d7';
 
   await deployThroughDeterministicFactory({
     deployer,
@@ -16,8 +16,8 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     contract: 'contracts/DCAHubCompanion/DCAHubCompanion.sol:DCAHubCompanion',
     bytecode,
     constructorArgs: {
-      types: ['address', 'address', 'address'],
-      values: [swapperRegistry.address, msig, permit2],
+      types: ['address', 'address', 'address', 'address'],
+      values: [swapper, swapper, msig, permit2],
     },
     log: !process.env.TEST,
     overrides: !!process.env.COVERAGE

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@commitlint/cli": "16.2.4",
     "@commitlint/config-conventional": "16.2.4",
     "@defi-wonderland/smock": "2.2.0",
-    "@mean-finance/sdk": "^0.0.118",
+    "@mean-finance/sdk": "0.0.119",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@0.3.0-beta.13",
     "@nomiclabs/hardhat-etherscan": "3.1.0",
     "@nomiclabs/hardhat-waffle": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@0xged/hardhat-deploy": "0.11.5",
+    "@mean-finance/call-simulation": "^0.0.1",
     "@mean-finance/dca-v2-core": "3.3.0",
     "@mean-finance/deterministic-factory": "1.6.0",
     "@mean-finance/swappers": "1.1.0",

--- a/test/integration/DCAHubCompanion/multi-call.spec.ts
+++ b/test/integration/DCAHubCompanion/multi-call.spec.ts
@@ -614,9 +614,7 @@ contract('Multicall', () => {
     return data!;
   }
 
-  type Swap = (_: {
-    amountIn: BigNumber;
-  }) => Promise<{
+  type Swap = (_: { amountIn: BigNumber }) => Promise<{
     tokenIn: string;
     tokenOut: string;
     swapper: string;

--- a/test/integration/DCAHubCompanion/multi-call.spec.ts
+++ b/test/integration/DCAHubCompanion/multi-call.spec.ts
@@ -7,7 +7,6 @@ import evm, { snapshot } from '@test-utils/evm';
 import { DCAHubCompanion, CallerOnlyDCAHubSwapper, IERC20 } from '@typechained';
 import { DCAHub, DCAPermissionsManager } from '@mean-finance/dca-v2-core';
 import { TransformerRegistry } from '@mean-finance/transformers';
-import { SwapperRegistry } from '@mean-finance/swappers';
 import { TransformerOracle, StatefulChainlinkOracle } from '@mean-finance/oracles';
 import { abi as DCA_HUB_ABI } from '@mean-finance/dca-v2-core/artifacts/contracts/DCAHub/DCAHub.sol/DCAHub.json';
 import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
@@ -36,7 +35,7 @@ contract('Multicall', () => {
   let DCAHubCompanion: DCAHubCompanion;
   let DCAPermissionManager: DCAPermissionsManager;
   let DCAHub: DCAHub;
-  let swapperRegistry: SwapperRegistry;
+  let companionSwapper: string;
   let DCAHubSwapper: CallerOnlyDCAHubSwapper;
   let transformerRegistry: TransformerRegistry;
   let permit2Address: string;
@@ -57,10 +56,10 @@ contract('Multicall', () => {
     DCAPermissionManager = await ethers.getContract('PermissionsManager');
     transformerRegistry = await ethers.getContract('TransformerRegistry');
 
-    swapperRegistry = await ethers.getContract<SwapperRegistry>('SwapperRegistry');
     const transformerOracle = await ethers.getContract<TransformerOracle>('TransformerOracle');
     const protocolTokenTransformer = await ethers.getContract('ProtocolTokenWrapperTransformer');
     const chainlinkOracle = await ethers.getContract<StatefulChainlinkOracle>('StatefulChainlinkOracle');
+    companionSwapper = await DCAHubCompanion.swapper();
 
     WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
     USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);
@@ -83,7 +82,6 @@ contract('Multicall', () => {
     permit2Address = await DCAHubCompanion.PERMIT2();
     await USDC.connect(positionOwner).approve(permit2Address, constants.MAX_UINT_256);
 
-    await swapperRegistry.connect(admin).allowSwappers([transformerRegistry.address]);
     await transformerRegistry
       .connect(admin)
       .registerTransformers([{ transformer: protocolTokenTransformer.address, dependents: [WETH.address] }]);
@@ -114,7 +112,7 @@ contract('Multicall', () => {
           let minExpected: BigNumber;
           given(async () => {
             const takeData = await permitTakeFromCallerDataIfUSDC({ from, amount: USDC_1000 });
-            const { swapExecutionData, expectedAmountOut } = await runSwapData({ tokenIn: await getAddress(from), amountIn: AMOUNT_IN, swap });
+            const { swapExecutionData, expectedAmountOut } = await runSwapData({ amountIn: AMOUNT_IN, swap });
             const depositData = await depositAllInCompanionData({ from: WETH, to: WBTC });
             await DCAHubCompanion.multicall(filterMulticalls([takeData, swapExecutionData, depositData]), {
               value: from === 'ETH' ? AMOUNT_IN : 0,
@@ -149,7 +147,7 @@ contract('Multicall', () => {
           given(async () => {
             const { positionId: createdPositionId, unswappedBalance } = await depositAndSwap({ from: WETH, to: USDC, amount: ETH_1 });
             const takeData = await permitTakeFromCallerDataIfUSDC({ from, amount: USDC_1000 });
-            const { swapExecutionData, expectedAmountOut } = await runSwapData({ tokenIn: await getAddress(from), amountIn: AMOUNT_IN, swap });
+            const { swapExecutionData, expectedAmountOut } = await runSwapData({ amountIn: AMOUNT_IN, swap });
             const permissionData = await givePermissionToCompanionData({
               signer: positionOwner,
               positionId: createdPositionId,
@@ -194,8 +192,8 @@ contract('Multicall', () => {
               positionId,
               permissions: [Permission.WITHDRAW],
             });
-            const withdrawData = await withdrawSwappedData({ positionId, recipient: DCAHubCompanion });
-            const { swapExecutionData, expectedAmountOut } = await runSwapData({ tokenIn: WETH.address, amountIn: swappedBalance, swap });
+            const withdrawData = await withdrawSwappedData({ positionId, recipient: companionSwapper });
+            const { swapExecutionData, expectedAmountOut } = await runSwapData({ amountIn: swappedBalance, swap });
             const sendData = await sendAllInCompanionToRecipientData({ token: await getAddress(to), recipient });
             await DCAHubCompanion.multicall([permissionData, withdrawData, swapExecutionData, sendData]);
             minExpected = expectedAmountOut;
@@ -231,8 +229,8 @@ contract('Multicall', () => {
           given(async () => {
             const { positionId, unswappedBalance } = await depositAndSwap({ from: WETH, to: USDC, amount: ETH_1 });
             const permissionData = await givePermissionToCompanionData({ signer: positionOwner, positionId, permissions: [Permission.REDUCE] });
-            const reduceData = await reduceAllPositionData({ positionId, recipient: DCAHubCompanion });
-            const { swapExecutionData, expectedAmountOut } = await runSwapData({ tokenIn: WETH.address, amountIn: unswappedBalance, swap });
+            const reduceData = await reduceAllPositionData({ positionId, recipient: companionSwapper });
+            const { swapExecutionData, expectedAmountOut } = await runSwapData({ amountIn: unswappedBalance, swap });
             const sendData = await sendAllInCompanionToRecipientData({ token: await getAddress(to), recipient });
             await DCAHubCompanion.multicall([permissionData, reduceData, swapExecutionData, sendData]);
             minExpected = expectedAmountOut;
@@ -259,20 +257,18 @@ contract('Multicall', () => {
         given(async () => {
           const { positionId, swappedBalance, unswappedBalance } = await depositAndSwap({ from: WETH, to: USDC, amount: ETH_1 });
           const permissionData = await givePermissionToCompanionData({ signer: positionOwner, positionId, permissions: [Permission.TERMINATE] });
-          const terminateData = await terminateAndSendToCompanionData({ positionId });
+          const _terminateData = await terminateData({ positionId, recipient: companionSwapper });
           const { swapExecutionData: executionDataETH, expectedAmountOut: _expectedAmountOutETH } = await runSwapData({
-            tokenIn: WETH.address,
             amountIn: unswappedBalance,
             swap: ({ amountIn }) => transformWETHToETH(amountIn),
           });
           const { swapExecutionData: executionDataWBTC, expectedAmountOut: _expectedAmountOutBTC } = await runSwapData({
-            tokenIn: USDC.address,
             amountIn: swappedBalance,
             swap: ({ amountIn }) => swapInDex({ from: USDC, to: WBTC, amountIn }),
           });
           const sendETHData = await sendAllInCompanionToRecipientData({ token: await DCAHubCompanion.PROTOCOL_TOKEN(), recipient });
           const sendWBTCData = await sendAllERC20InCompanionToRecipientData({ token: WBTC, recipient });
-          await DCAHubCompanion.multicall([permissionData, terminateData, executionDataETH, sendETHData, executionDataWBTC, sendWBTCData]);
+          await DCAHubCompanion.multicall([permissionData, _terminateData, executionDataETH, sendETHData, executionDataWBTC, sendWBTCData]);
           expectedAmountOutETH = _expectedAmountOutETH;
           expectedAmountOutBTC = _expectedAmountOutBTC;
         });
@@ -620,37 +616,59 @@ contract('Multicall', () => {
 
   type Swap = (_: {
     amountIn: BigNumber;
-  }) => Promise<{ swapper: string; allowanceTarget: string; swapData: BytesLike; expectedAmountOut: BigNumber }>;
-  async function runSwapData({ tokenIn, amountIn, swap }: { tokenIn: string; amountIn: BigNumber; swap: Swap }) {
-    const { swapper, swapData, expectedAmountOut, allowanceTarget } = await swap({ amountIn });
-    const { data } = await DCAHubCompanion.populateTransaction.runSwap({
-      swapper,
-      allowanceTarget,
-      swapData,
-      tokenIn,
-      amountIn,
+  }) => Promise<{
+    tokenIn: string;
+    tokenOut: string;
+    swapper: string;
+    allowanceTarget: string;
+    swapData: string;
+    expectedAmountOut: BigNumber;
+    value?: BigNumber;
+  }>;
+  async function runSwapData({ amountIn, swap }: { amountIn: BigNumber; swap: Swap }) {
+    const { tokenIn, tokenOut, swapper, swapData, expectedAmountOut, allowanceTarget, value } = await swap({ amountIn });
+    const allowanceTargets = isSameAddress(allowanceTarget, constants.ZERO_ADDRESS) ? [] : [{ token: tokenIn, target: allowanceTarget }];
+    const tokenOutDistribution = isSameAddress(tokenOut, await DCAHubCompanion.PROTOCOL_TOKEN()) ? constants.ZERO_ADDRESS : tokenOut;
+
+    const arbitraryCall = buildSDK().permit2Service.arbitrary.buildArbitraryCallWithoutPermit({
+      allowanceTargets,
+      calls: [{ to: swapper, data: swapData, value: value?.toBigInt() ?? 0 }],
+      distribution: { [tokenOutDistribution]: [{ recipient: DCAHubCompanion.address, shareBps: 0 }] },
+      txValidFor: '1y',
     });
+    const { data } = await DCAHubCompanion.populateTransaction.runSwap(
+      constants.ZERO_ADDRESS, // No need to set it because we are already transferring the funds to the swapper
+      value?.toBigInt() ?? 0,
+      arbitraryCall.data,
+      tokenOut,
+      expectedAmountOut
+    );
     return { swapExecutionData: data!, expectedAmountOut };
   }
 
-  async function withdrawSwappedData({ positionId, recipient }: { positionId: BigNumberish; recipient: HasAddress }) {
-    const { data } = await DCAHubCompanion.populateTransaction.withdrawSwapped(DCAHub.address, positionId, recipient.address);
-    return data!;
-  }
-
-  async function reduceAllPositionData({ positionId, recipient }: { positionId: BigNumberish; recipient: HasAddress }) {
-    const { remaining } = await DCAHub.userPosition(positionId);
-    const { data } = await DCAHubCompanion.populateTransaction.reducePosition(DCAHub.address, positionId, remaining, 0, recipient.address);
-    return data!;
-  }
-
-  async function terminateAndSendToCompanionData({ positionId }: { positionId: BigNumberish }) {
-    const { data } = await DCAHubCompanion.populateTransaction.terminate(
+  async function withdrawSwappedData({ positionId, recipient }: { positionId: BigNumberish; recipient: HasAddress | string }) {
+    const { data } = await DCAHubCompanion.populateTransaction.withdrawSwapped(
       DCAHub.address,
       positionId,
-      DCAHubCompanion.address,
-      DCAHubCompanion.address
+      typeof recipient === 'string' ? recipient : recipient.address
     );
+    return data!;
+  }
+
+  async function reduceAllPositionData({ positionId, recipient }: { positionId: BigNumberish; recipient: HasAddress | string }) {
+    const { remaining } = await DCAHub.userPosition(positionId);
+    const { data } = await DCAHubCompanion.populateTransaction.reducePosition(
+      DCAHub.address,
+      positionId,
+      remaining,
+      0,
+      typeof recipient === 'string' ? recipient : recipient.address
+    );
+    return data!;
+  }
+
+  async function terminateData({ positionId, recipient }: { positionId: BigNumberish; recipient: string }) {
+    const { data } = await DCAHubCompanion.populateTransaction.terminate(DCAHub.address, positionId, recipient, recipient);
     return data!;
   }
 
@@ -706,7 +724,14 @@ contract('Multicall', () => {
     deadline: BigNumberish;
     signature: string;
   }) {
-    const { data } = await DCAHubCompanion.populateTransaction.permitTakeFromCaller(token.address, amount, nonce, deadline, signature);
+    const { data } = await DCAHubCompanion.populateTransaction.permitTakeFromCaller(
+      token.address,
+      amount,
+      nonce,
+      deadline,
+      signature,
+      companionSwapper
+    );
     return data!;
   }
 
@@ -725,11 +750,12 @@ contract('Multicall', () => {
   }
 
   async function transformWETHToETH(amount: BigNumber) {
+    const nativeToken = await DCAHubCompanion.PROTOCOL_TOKEN();
     const { data } = await transformerRegistry.populateTransaction.transformToUnderlying(
       WETH.address,
       amount,
       DCAHubCompanion.address,
-      [{ underlying: await DCAHubCompanion.PROTOCOL_TOKEN(), amount }],
+      [{ underlying: nativeToken, amount }],
       constants.MAX_UINT_256
     );
     return {
@@ -737,13 +763,16 @@ contract('Multicall', () => {
       swapper: transformerRegistry.address,
       expectedAmountOut: amount,
       allowanceTarget: transformerRegistry.address,
+      tokenIn: WETH.address,
+      tokenOut: nativeToken,
     };
   }
 
   async function transformETHToWETH(amount: BigNumber) {
+    const nativeToken = await DCAHubCompanion.PROTOCOL_TOKEN();
     const { data } = await transformerRegistry.populateTransaction.transformToDependent(
       WETH.address,
-      [{ underlying: await DCAHubCompanion.PROTOCOL_TOKEN(), amount }],
+      [{ underlying: nativeToken, amount }],
       DCAHubCompanion.address,
       amount,
       constants.MAX_UINT_256
@@ -753,41 +782,40 @@ contract('Multicall', () => {
       swapper: transformerRegistry.address,
       expectedAmountOut: amount,
       allowanceTarget: constants.ZERO_ADDRESS,
+      tokenIn: nativeToken,
+      tokenOut: WETH.address,
+      value: amount,
     };
   }
 
   async function swapInDex({ from, to, amountIn }: { from: IERC20; to: IERC20; amountIn: BigNumber }) {
     const { quoteService } = buildSDK();
-    const quotes = await quoteService.getAllQuotes({
+    const {
+      tx,
+      minBuyAmount,
+      source: { allowanceTarget },
+    } = await quoteService.getBestQuote({
       request: {
         chainId: 1,
         sellToken: from.address,
         buyToken: to.address,
         order: { type: 'sell', sellAmount: amountIn.toString() },
         slippagePercentage: 5, // 5%
-        takerAddress: DCAHubCompanion.address,
-        filters: { includeSources: ['1inch', 'paraswap'] },
+        takerAddress: companionSwapper,
+        filters: { includeSources: ['1inch', 'paraswap', 'open-ocean', 'li-fi'] },
       },
       config: {
         timeout: '3s',
-        ignoredFailed: true,
-        sort: { by: 'most-swapped', using: 'max sell/min buy amounts' },
+        choose: { by: 'most-swapped', using: 'max sell/min buy amounts' },
       },
     });
-    const {
-      tx,
-      minBuyAmount,
-      source: { allowanceTarget },
-    } = quotes[0];
-    await swapperRegistry.connect(admin).allowSwappers([tx.to]);
-    if (!isSameAddress(tx.to, allowanceTarget)) {
-      await swapperRegistry.connect(admin).allowSupplementaryAllowanceTargets([allowanceTarget]);
-    }
     return {
       swapData: tx.data,
       swapper: tx.to,
       expectedAmountOut: BigNumber.from(minBuyAmount.amount),
       allowanceTarget,
+      tokenIn: from.address,
+      tokenOut: to.address,
     };
   }
 

--- a/test/unit/utils/base-companion.spec.ts
+++ b/test/unit/utils/base-companion.spec.ts
@@ -2,9 +2,10 @@ import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { contract, given, then, when } from '@test-utils/bdd';
 import { snapshot } from '@test-utils/evm';
-import { BaseCompanionMock, BaseCompanionMock__factory, IERC20, IPermit2 } from '@typechained';
+import behaviors from '@test-utils/behaviours';
+import { BaseCompanionMock, BaseCompanionMock__factory, IERC20, IPermit2, ISwapper } from '@typechained';
 import { FakeContract, smock } from '@defi-wonderland/smock';
-import { Wallet } from 'ethers';
+import { BytesLike, Wallet, constants } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 chai.use(smock.matchers);
@@ -14,8 +15,9 @@ contract('BaseCompanion', () => {
   const RECIPIENT = Wallet.createRandom();
   let token: FakeContract<IERC20>;
   let permit2: FakeContract<IPermit2>;
+  let swapper: FakeContract<ISwapper>;
   let baseCompanion: BaseCompanionMock;
-  let caller: SignerWithAddress;
+  let caller: SignerWithAddress, governor: SignerWithAddress;
   let snapshotId: string;
 
   before('Setup accounts and contracts', async () => {
@@ -23,14 +25,17 @@ contract('BaseCompanion', () => {
     const registry = await smock.fake('ISwapperRegistry');
     token = await smock.fake('IERC20');
     permit2 = await smock.fake('IPermit2');
-    [caller] = await ethers.getSigners();
-    baseCompanion = await baseCompanionFactory.deploy(registry.address, RECIPIENT.address, permit2.address);
+    swapper = await smock.fake('ISwapper');
+    [caller, governor] = await ethers.getSigners();
+    baseCompanion = await baseCompanionFactory.deploy(swapper.address, swapper.address, governor.address, permit2.address);
     snapshotId = await snapshot.take();
   });
 
   beforeEach(async () => {
     await snapshot.revert(snapshotId);
     token.transfer.reset();
+    token.balanceOf.reset();
+    token.approve.reset();
     token.transferFrom.returns(true);
     token.transfer.returns(true);
   });
@@ -65,6 +70,42 @@ contract('BaseCompanion', () => {
     });
   });
 
+  describe('runSwap', () => {
+    let swapExecution: BytesLike;
+    given(async () => {
+      const { data } = await swapper.populateTransaction.swap(token.address, 1000, token.address);
+      swapExecution = data!;
+    });
+    when('swap is executed', () => {
+      given(async () => {
+        await baseCompanion.runSwap(token.address, 0, swapExecution, token.address, 0);
+      });
+      then('max approval is given', () => {
+        expect(token.approve).to.have.been.calledOnceWith(swapper.address, constants.MaxUint256);
+      });
+      then('swapper is called correctly', () => {
+        expect(swapper.swap).to.have.been.calledWith(token.address, 1000, token.address);
+      });
+      then('balance is checked correctly', () => {
+        expect(token.balanceOf).to.have.been.calledOnceWith(baseCompanion.address);
+      });
+    });
+    when('allowance token is not set', () => {
+      given(async () => {
+        await baseCompanion.runSwap(constants.AddressZero, 0, swapExecution, token.address, 0);
+      });
+      then('approve is not called', () => {
+        expect(token.approve).to.not.have.been.called;
+      });
+    });
+    when('returned balance is less than expected', () => {
+      then('call reverts', async () => {
+        const tx = baseCompanion.runSwap(constants.AddressZero, 0, swapExecution, token.address, 1);
+        expect(tx).to.have.revertedWith('ReceivedTooLittleTokenOut(0,1)');
+      });
+    });
+  });
+
   describe('sendBalanceOnContractToRecipient', () => {
     when('sending balance on contract to a recipient', () => {
       given(async () => {
@@ -82,7 +123,7 @@ contract('BaseCompanion', () => {
   describe('permitTakeFromCaller', () => {
     when('taking from caller with permit', () => {
       given(async () => {
-        await baseCompanion.permitTakeFromCaller(token.address, 12345, 678910, 2468, '0x1234');
+        await baseCompanion.permitTakeFromCaller(token.address, 12345, 678910, 2468, '0x1234', swapper.address);
       });
       then('internal function is called correctly', async () => {
         expect(permit2['permitTransferFrom(((address,uint256),uint256,uint256),(address,uint256),address,bytes)']).to.have.been.calledOnce;
@@ -93,7 +134,7 @@ contract('BaseCompanion', () => {
         expect(permit.permitted.amount).to.equal(12345);
         expect(permit.nonce).to.equal(678910);
         expect(permit.deadline).to.equal(2468);
-        expect(transferDetails.to).to.equal(baseCompanion.address);
+        expect(transferDetails.to).to.equal(swapper.address);
         expect(transferDetails.requestedAmount).to.equal(12345);
         expect(owner).to.equal(caller.address);
         expect(signature).to.equal('0x1234');
@@ -104,7 +145,7 @@ contract('BaseCompanion', () => {
   describe('batchPermitTakeFromCaller', () => {
     when('taking from caller with permit', () => {
       given(async () => {
-        await baseCompanion.batchPermitTakeFromCaller([{ token: token.address, amount: 12345 }], 678910, 2468, '0x1234');
+        await baseCompanion.batchPermitTakeFromCaller([{ token: token.address, amount: 12345 }], 678910, 2468, '0x1234', swapper.address);
       });
       then('internal function is called correctly', async () => {
         expect(permit2['permitTransferFrom(((address,uint256)[],uint256,uint256),(address,uint256)[],address,bytes)']).to.have.been.calledOnce;
@@ -117,11 +158,31 @@ contract('BaseCompanion', () => {
         expect(permit.nonce).to.equal(678910);
         expect(permit.deadline).to.equal(2468);
         expect(transferDetails).to.have.lengthOf(1);
-        expect(transferDetails[0].to).to.equal(baseCompanion.address);
+        expect(transferDetails[0].to).to.equal(swapper.address);
         expect(transferDetails[0].requestedAmount).to.equal(12345);
         expect(owner).to.equal(caller.address);
         expect(signature).to.equal('0x1234');
       });
+    });
+  });
+
+  describe('setSwapper', () => {
+    const newSwapper = '0x0000000000000000000000000000000000000001';
+    const newAllowanceTarget = '0x0000000000000000000000000000000000000001';
+    when('setting a new swapper', () => {
+      given(async () => {
+        await baseCompanion.connect(governor).setSwapper(newSwapper, newAllowanceTarget);
+      });
+      then('it is set correctly', async () => {
+        expect(await baseCompanion.swapper()).to.equal(newSwapper);
+        expect(await baseCompanion.allowanceTarget()).to.equal(newAllowanceTarget);
+      });
+    });
+    behaviors.shouldBeExecutableOnlyByGovernor({
+      contract: () => baseCompanion,
+      funcAndSignature: 'setSwapper',
+      params: [newSwapper, newSwapper],
+      governor: () => governor,
     });
   });
 });

--- a/test/unit/utils/base-companion.spec.ts
+++ b/test/unit/utils/base-companion.spec.ts
@@ -168,7 +168,7 @@ contract('BaseCompanion', () => {
 
   describe('setSwapper', () => {
     const newSwapper = '0x0000000000000000000000000000000000000001';
-    const newAllowanceTarget = '0x0000000000000000000000000000000000000001';
+    const newAllowanceTarget = '0x0000000000000000000000000000000000000002';
     when('setting a new swapper', () => {
       given(async () => {
         await baseCompanion.connect(governor).setSwapper(newSwapper, newAllowanceTarget);

--- a/test/utils/behaviours.ts
+++ b/test/utils/behaviours.ts
@@ -198,7 +198,7 @@ const shouldBeExecutableOnlyByGovernor = ({
         [funcAndSignature](...realParams!);
     });
     then('tx is reverted with reason', async () => {
-      await expect(onlyGovernorAllowedTx).to.be.revertedWith('Governable: only governor');
+      await expect(onlyGovernorAllowedTx).to.be.revertedWith('OnlyGovernor');
     });
   });
   when('called from governor', () => {
@@ -209,7 +209,7 @@ const shouldBeExecutableOnlyByGovernor = ({
         [funcAndSignature](...realParams!);
     });
     then('tx is not reverted or not reverted with reason only governor', async () => {
-      await expect(onlyGovernorAllowedTx).to.not.be.revertedWith('Governable: only governor');
+      await expect(onlyGovernorAllowedTx).to.not.be.revertedWith('OnlyGovernor');
     });
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,10 +1278,10 @@
     "@uniswap/v3-core" "1.0.1"
     moment "2.29.3"
 
-"@mean-finance/sdk@^0.0.118":
-  version "0.0.118"
-  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.118.tgz#240b2ef7e8c5d81bda4c999e6ed37c5664c7d6e9"
-  integrity sha512-u/LIWrl+azwdQQVY2W9KqSu3wuyUCdUq8fgoqEGzBI1alNSKDOXivFATulgXWiYmtdNOPr0ZsOEULw44B5yhwA==
+"@mean-finance/sdk@0.0.119":
+  version "0.0.119"
+  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.119.tgz#81b8f04bc560d507df499a068000c3d2d11bd4e7"
+  integrity sha512-U4RR0Ex0DQtV+clkUgIPkbtTox3JDeBau+pP+bjlI/PPli1iNxkbtFY2kapMxaM266sreTNYMg3eS1RxllUdLg==
   dependencies:
     alchemy-sdk "2.9.0"
     cross-fetch "3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,6 +1216,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@mean-finance/call-simulation@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@mean-finance/call-simulation/-/call-simulation-0.0.1.tgz#719acb89e736add8fbe09a08daa342459457cea5"
+  integrity sha512-WngN+1AqJAcEcP148SO84ENQfwFloZmKxA7CN8Dlk3J7fS+xaVX1j6QIXLiCouI4OkuKBw7JzeRfjzWmESTk7A==
+
 "@mean-finance/chainlink-registry@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@mean-finance/chainlink-registry/-/chainlink-registry-2.1.0.tgz#f11d78a617a9e0e9f2aec6b7b0f6fe2db07b86fe"


### PR DESCRIPTION
We are now making a change to the Companion so that we don't have to use the swapper registry. Before this change, we would call swappers directly from the Companion, which would be an arbitrary address. Since they Companion also handles approvals, we would need a whitelist (the registry) to make sure funds couldn't be transferred. Despite all this, when we used the swapper, we would actually use the SwapProxy because it supported multi-step swaps. 

So the idea here it that the Companion will now have a pre-defined swapper (and allowance target), instead of taking an arbitrary address. This will allow us to get rid of the whitelist.

The regular workflow will looks something like:
1. Companion use Permit2 to transfer tokens from the caller to the Permit2Adapter contract
2. Companion calls the Permit2Adapter contract to execute a swap against another party (like 0x, 1inch, Paraswap, etc)
3. The Permit2Adapter will send the funds to the Companion
4. The Companion will make sure it received a minimum amount of tokens
