### PR TITLE
refactor: add test mode to 3rd party swapper

### DIFF
--- a/deploy/003_third_party_swapper.ts
+++ b/deploy/003_third_party_swapper.ts
@@ -9,7 +9,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
   await deployThroughDeterministicFactory({
     deployer,
     name: 'ThirdPartyDCAHubSwapper',
-    salt: 'MF-DCAV2-3PartySwapper-V2',
+    salt: 'MF-DCAV2-3PartySwapper-V3',
     contract: 'contracts/DCAHubSwapper/ThirdPartyDCAHubSwapper.sol:ThirdPartyDCAHubSwapper',
     bytecode,
     constructorArgs: {

--- a/test/integration/DCAHubSwapper/multi-pair-swap-with-dex.spec.ts
+++ b/test/integration/DCAHubSwapper/multi-pair-swap-with-dex.spec.ts
@@ -171,7 +171,6 @@ contract('Multi pair swap with DEX', () => {
             { swapper: dexQuotes[0].tx.to, data: dexQuotes[0].tx.data },
             { swapper: dexQuotes[1].tx.to, data: dexQuotes[1].tx.data },
           ],
-          sendToProvideLeftoverToHub: false,
         });
         const swapTx = await DCAHub.connect(swapStarter).swap(
           tokensInSwap,
@@ -215,19 +214,18 @@ contract('Multi pair swap with DEX', () => {
     allowanceTargets?: { token: string; spender: string; amount: BigNumberish }[];
     executions: { data: BytesLike; swapper: string }[];
     extraTokens?: string[];
-    sendToProvideLeftoverToHub?: boolean;
   };
   function encode(bytes: SwapData) {
     return ABI_CODER.encode(
-      ['tuple(uint256, tuple(address, address, uint256)[], tuple(address, uint256, bytes)[], address[], address, bool)'],
+      ['tuple(bool, uint256, tuple(address, address, uint256)[], tuple(address, uint256, bytes)[], address[], address)'],
       [
         [
+          false,
           constants.MAX_UINT_256,
           bytes.allowanceTargets?.map(({ token, spender, amount }) => [token, spender, amount]) ?? [],
           bytes.executions?.map(({ swapper, data }) => [swapper, 0, data]) ?? [],
           bytes.extraTokens ?? [],
           recipient.address,
-          bytes.sendToProvideLeftoverToHub ?? false,
         ],
       ]
     );

--- a/test/integration/DCAHubSwapper/swap-with-dex-native.spec.ts
+++ b/test/integration/DCAHubSwapper/swap-with-dex-native.spec.ts
@@ -111,7 +111,6 @@ contract('Swap with DEX, using native', () => {
         const data = encode({
           allowanceTargets: [],
           executions: [{ swapper: dexQuote.tx.to, data: dexQuote.tx.data, value: RATE }],
-          sendToProvideLeftoverToHub: true,
         });
         const swapTx = await DCAHubSwapper.connect(swapStarter).executeSwap(DCAHub.address, tokensInSwap, indexesInSwap, [0, 0], data, '0x', {
           value: RATE,
@@ -142,19 +141,18 @@ contract('Swap with DEX, using native', () => {
     allowanceTargets?: { token: string; spender: string; amount: BigNumberish }[];
     executions: { data: BytesLike; swapper: string; value: BigNumberish }[];
     extraTokens?: string[];
-    sendToProvideLeftoverToHub?: boolean;
   };
   function encode(bytes: SwapData) {
     return ABI_CODER.encode(
-      ['tuple(uint256, tuple(address, address, uint256)[], tuple(address, uint256, bytes)[], address[], address, bool)'],
+      ['tuple(bool, uint256, tuple(address, address, uint256)[], tuple(address, uint256, bytes)[], address[], address)'],
       [
         [
+          false,
           constants.MAX_UINT_256,
           bytes.allowanceTargets?.map(({ token, spender, amount }) => [token, spender, amount]) ?? [],
           bytes.executions?.map(({ swapper, data, value }) => [swapper, value, data]) ?? [],
           bytes.extraTokens ?? [],
           recipient.address,
-          bytes.sendToProvideLeftoverToHub ?? false,
         ],
       ]
     );


### PR DESCRIPTION
We are now making two changes:
1. We are removing the `sendToProvideLeftoverToHub` flag. We are the only ones using this contract, and it was always set to true, so it didn't make much sense to have it anymore
2. We are adding an `isTest` flag. If set to true, we will calculate all balances on the contract and report them via revert. This will allow us to simulate quotes 🔥 