### PR TITLE
chore: alias @openzeppelin/contracts

### DIFF
--- a/contracts/DCAFeeManager/DCAFeeManager.sol
+++ b/contracts/DCAFeeManager/DCAFeeManager.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.22;
 
-import '@openzeppelin/contracts/access/AccessControl.sol';
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
-import '@openzeppelin/contracts/utils/Multicall.sol';
+import '@openzeppelin/contracts-5.0.1/access/AccessControl.sol';
+import '@openzeppelin/contracts-5.0.1/token/ERC20/utils/SafeERC20.sol';
+import '@openzeppelin/contracts-5.0.1/utils/Multicall.sol';
+import {IERC20 as IERC20_4_7_3} from '@openzeppelin/contracts-4.7.3/token/ERC20/IERC20.sol';
 import '../interfaces/IDCAFeeManager.sol';
 
 contract DCAFeeManager is SwapAdapter, AccessControl, Multicall, IDCAFeeManager {
@@ -94,7 +95,7 @@ contract DCAFeeManager is SwapAdapter, AccessControl, Multicall, IDCAFeeManager 
       AmountToFill memory _amount = _amounts[i];
 
       _maxApproveSpenderIfNeeded(
-        IERC20(_amount.token),
+        IERC20_4_7_3(_amount.token),
         address(_hub),
         true, // No need to check if the hub is a valid allowance target
         _amount.amount

--- a/contracts/DCAHubCompanion/DCAHubCompanion.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanion.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.8.22;
 
 import './DCAHubCompanionLibrariesHandler.sol';
-import './DCAHubCompanionHubProxyHandler.sol';
-import '../utils/BaseCompanion.sol';
+import {DCAHubCompanionHubProxyHandler} from './DCAHubCompanionHubProxyHandler.sol';
+import {BaseCompanion, IPermit2} from '../utils/BaseCompanion.sol';
 
 contract DCAHubCompanion is DCAHubCompanionLibrariesHandler, DCAHubCompanionHubProxyHandler, BaseCompanion, IDCAHubCompanion {
   constructor(

--- a/contracts/DCAHubCompanion/DCAHubCompanionHubProxyHandler.sol
+++ b/contracts/DCAHubCompanion/DCAHubCompanionHubProxyHandler.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.22;
 
-import '../interfaces/IDCAHubCompanion.sol';
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IDCAHubCompanionLibrariesHandler, IDCAHubCompanionHubProxyHandler, IDCAPermissionManager, IDCAHub, IERC20Metadata} from '../interfaces/IDCAHubCompanion.sol';
+import '@openzeppelin/contracts-5.0.1/token/ERC20/utils/SafeERC20.sol';
 
 /// @dev All public functions are payable, so that they can be multicalled together with other payable functions when msg.value > 0
 abstract contract DCAHubCompanionHubProxyHandler is IDCAHubCompanionHubProxyHandler {

--- a/contracts/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol
+++ b/contracts/DCAHubSwapper/CallerOnlyDCAHubSwapper.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.22;
 
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
-import '../interfaces/ICallerOnlyDCAHubSwapper.sol';
+import '@openzeppelin/contracts-5.0.1/token/ERC20/utils/SafeERC20.sol';
+import {ICallerOnlyDCAHubSwapper, IDCAHub} from '../interfaces/ICallerOnlyDCAHubSwapper.sol';
 import './utils/DeadlineValidation.sol';
 
 contract CallerOnlyDCAHubSwapper is DeadlineValidation, ICallerOnlyDCAHubSwapper {

--- a/contracts/DCAHubSwapper/ThirdPartyDCAHubSwapper.sol
+++ b/contracts/DCAHubSwapper/ThirdPartyDCAHubSwapper.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.22;
 
-import '@openzeppelin/contracts/access/IAccessControl.sol';
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
-import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHubSwapCallee.sol';
+import '@openzeppelin/contracts-5.0.1/access/IAccessControl.sol';
+import '@openzeppelin/contracts-5.0.1/token/ERC20/utils/SafeERC20.sol';
+import {IDCAHubSwapCallee, IDCAHub} from '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHubSwapCallee.sol';
 
 contract ThirdPartyDCAHubSwapper is IDCAHubSwapCallee {
   /// @notice A target we want to give allowance to

--- a/contracts/DCAKeep3rJob/DCAKeep3rJob.sol
+++ b/contracts/DCAKeep3rJob/DCAKeep3rJob.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.22;
 
-import '@openzeppelin/contracts/access/AccessControl.sol';
-import '@openzeppelin/contracts/utils/Address.sol';
-import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
-import '@openzeppelin/contracts/utils/cryptography/EIP712.sol';
+import '@openzeppelin/contracts-5.0.1/access/AccessControl.sol';
+import '@openzeppelin/contracts-5.0.1/utils/Address.sol';
+import '@openzeppelin/contracts-5.0.1/utils/cryptography/ECDSA.sol';
+import '@openzeppelin/contracts-5.0.1/utils/cryptography/EIP712.sol';
 import '../interfaces/IDCAKeep3rJob.sol';
 
 contract DCAKeep3rJob is AccessControl, EIP712, IDCAKeep3rJob {

--- a/contracts/interfaces/ICallerOnlyDCAHubSwapper.sol
+++ b/contracts/interfaces/ICallerOnlyDCAHubSwapper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7;
 
-import '@openzeppelin/contracts/access/IAccessControl.sol';
+import '@openzeppelin/contracts-5.0.1/access/IAccessControl.sol';
 import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHub.sol';
 import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHubSwapCallee.sol';
 

--- a/contracts/interfaces/IDCAFeeManager.sol
+++ b/contracts/interfaces/IDCAFeeManager.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7;
 
-import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHub.sol';
-import '@mean-finance/swappers/solidity/contracts/extensions/TakeManyRunSwapsAndTransferMany.sol';
+import {IERC20} from '@openzeppelin/contracts-5.0.1/token/ERC20/extensions/IERC20Metadata.sol';
+import {IDCAHub, IDCAHubPositionHandler, IDCAPermissionManager, IERC20Metadata} from '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHub.sol';
+import {SwapContext, TransferOutBalance, ISwapAdapter, SwapAdapter} from '@mean-finance/swappers/solidity/contracts/extensions/TakeManyRunSwapsAndTransferMany.sol';
 
 /**
  * @title DCA Fee Manager

--- a/contracts/mocks/LegacyDCASwapper.sol
+++ b/contracts/mocks/LegacyDCASwapper.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.22;
 
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
-import '../interfaces/ILegacyDCAHub.sol';
+import '@openzeppelin/contracts-5.0.1/token/ERC20/utils/SafeERC20.sol';
+import {ILegacyDCAHub, IDCAHub} from '../interfaces/ILegacyDCAHub.sol';
 
 contract LegacyDCASwapper {
   using SafeERC20 for IERC20;

--- a/contracts/mocks/utils/BaseCompanion.sol
+++ b/contracts/mocks/utils/BaseCompanion.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.22;
 
 import '../../utils/BaseCompanion.sol';
+import {IERC20 as IERC20_4_7_3} from '@openzeppelin/contracts-4.7.3/token/ERC20/IERC20.sol';
 
 contract BaseCompanionMock is BaseCompanion {
   constructor(
@@ -12,7 +13,7 @@ contract BaseCompanionMock is BaseCompanion {
   ) BaseCompanion(_swapper, _allowanceTarget, _governor, _permit2) {}
 
   struct TakeFromMsgSenderCall {
-    IERC20 token;
+    IERC20_4_7_3 token;
     uint256 amount;
   }
 
@@ -43,7 +44,7 @@ contract BaseCompanionMock is BaseCompanion {
     return _sendToRecipientCalls;
   }
 
-  function _takeFromMsgSender(IERC20 _token, uint256 _amount) internal override {
+  function _takeFromMsgSender(IERC20_4_7_3 _token, uint256 _amount) internal override {
     _takeFromMsgSenderCalls.push(TakeFromMsgSenderCall(_token, _amount));
     super._takeFromMsgSender(_token, _amount);
   }

--- a/contracts/utils/BaseCompanion.sol
+++ b/contracts/utils/BaseCompanion.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.22;
 
-import '@mean-finance/swappers/solidity/contracts/extensions/RevokableWithGovernor.sol';
-import '@mean-finance/swappers/solidity/contracts/extensions/PayableMulticall.sol';
+import '@openzeppelin/contracts-5.0.1/token/ERC20/utils/SafeERC20.sol';
+import {RevokableWithGovernor, SwapAdapter, Governable} from '@mean-finance/swappers/solidity/contracts/extensions/RevokableWithGovernor.sol';
+import {PayableMulticall} from '@mean-finance/swappers/solidity/contracts/extensions/PayableMulticall.sol';
 import {SimulationAdapter} from '@mean-finance/call-simulation/contracts/SimulationAdapter.sol';
 import {IPermit2} from '../interfaces/external/IPermit2.sol';
 import {Permit2Transfers} from '../libraries/Permit2Transfers.sol';

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "@mean-finance/dca-v2-core": "3.4.0",
     "@mean-finance/deterministic-factory": "1.6.0",
     "@mean-finance/swappers": "1.2.0",
-    "@openzeppelin/contracts": "5.0.1",
+    "@openzeppelin/contracts-4.7.3": "npm:@openzeppelin/contracts@4.7.3",
+    "@openzeppelin/contracts-5.0.1": "npm:@openzeppelin/contracts@5.0.1",
     "keep3r-v2": "1.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,16 @@
     find-up "^4.1.0"
     fs-extra "^8.1.0"
 
+"@openzeppelin/contracts-4.7.3@npm:@openzeppelin/contracts@4.7.3", "@openzeppelin/contracts@4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
+  integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
+
+"@openzeppelin/contracts-5.0.1@npm:@openzeppelin/contracts@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.1.tgz#93da90fc209a0a4ff09c1deb037fbb35e4020890"
+  integrity sha512-yQJaT5HDp9hYOOp4jTYxMsR02gdFZFXhewX5HW9Jo4fsqSVqqyIO/xTHdWDaKX5a3pv1txmf076Lziz+sO7L1w==
+
 "@openzeppelin/contracts@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.0.tgz#9a1669ad5f9fdfb6e273bb5a4fed10cb4cc35eb0"
@@ -1608,20 +1618,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
   integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
 
-"@openzeppelin/contracts@4.7.3":
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
-  integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
-
 "@openzeppelin/contracts@4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.2.tgz#d815ade0027b50beb9bcca67143c6bcc3e3923d6"
   integrity sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g==
-
-"@openzeppelin/contracts@5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.1.tgz#93da90fc209a0a4ff09c1deb037fbb35e4020890"
-  integrity sha512-yQJaT5HDp9hYOOp4jTYxMsR02gdFZFXhewX5HW9Jo4fsqSVqqyIO/xTHdWDaKX5a3pv1txmf076Lziz+sO7L1w==
 
 "@openzeppelin/test-helpers@0.5.15":
   version "0.5.15"


### PR DESCRIPTION
This PR is slightly more complex than the other PRs that alias `@openzeppelin/contracts`. This is because the Solidity compiler was throwing an error due to the fact that this repo uses `IERC20` from OpenZeppelin v5.0.1 and also from OpenZeppelin v4.7.3 (imported from `swappers` and `dca-v2-core`). There were two types of error occurring because of this conflict, which I'll explain below.

A couple notes:
* Although this PR makes the imports slightly more complex, it doesn't change the behavior of the contracts.
* To remove the extra complexity in the imports, you can refactor the relevant repos (`dca-v2-periphery`, `dca-v2-core`, and `swappers`) to use a consistent version of OpenZeppelin contracts. If you do that, you'll need to slightly modify the functionality of some of your contracts.

### First type of error:

```
DeclarationError: Identifier already declared.
 --> contracts/DCAHubSwapper/ThirdPartyDCAHubSwapper.sol:6:1:
  |
6 | import '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHubSwapCallee.sol';
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: The previous declaration is here:
 --> @openzeppelin/contracts-5.0.1/token/ERC20/IERC20.sol:9:1:
  |
9 | interface IERC20 {
  | ^ (Relevant source part starts here and spans across multiple lines).
```

This error was occurring because `ThirdPartyDCAHubSwapper` was importing two different versions of `IERC20.sol`: one from OpenZeppelin v4.7.3 via `IDCAHubSwapCallee.sol` in `dca-v2-core`, and another from v5.0.1 directly from `@openzeppelin/contracts-5.0.1`. I'm pretty sure this error wasn't occurring before this PR because these repos were using a consistent name for OpenZeppelin's contracts (i.e. `@openzeppelin/contracts`).

This type of error occurred in a few other contracts too.

I resolved this issue by importing only the required files. For example:
```
import {IDCAHubSwapCallee, IDCAHub} from '@mean-finance/dca-v2-core/contracts/interfaces/IDCAHubSwapCallee.sol';
```

### Second type of error:

The other issue was that a couple contracts in this repo use two different versions of `IERC20.sol` (v4.7.3 and v5.0.1). Here's the error that was occurring because of this conflict:

```
TypeError: Invalid type for argument in function call. Invalid implicit conversion from contract IERC20 to contract IERC20 requested.
  --> contracts/mocks/utils/BaseCompanion.sol:48:30:
   |
48 |     super._takeFromMsgSender(_token, _amount);
   |                              ^^^^^^
```

Again, I believe this issue wasn't occurring before this PR because we now use aliases for `@openzeppelin/contracts`. I resolved this by aliasing `IERC20` v4.7.3:

```
import {IERC20 as IERC20_4_7_3} from '@openzeppelin/contracts-4.7.3/token/ERC20/IERC20.sol';
```
