### PR TITLE
refactor: remove min amount out from base companion

### DIFF
--- a/contracts/utils/BaseCompanion.sol
+++ b/contracts/utils/BaseCompanion.sol
@@ -17,13 +17,6 @@ abstract contract BaseCompanion is SimulationAdapter, RevokableWithGovernor, Pay
   using SafeERC20 for IERC20;
 
   /**
-   * @notice Thrown when the swap produced less token out than expected
-   * @param received The amount of token out received
-   * @param expected The amount of token out expected
-   */
-  error ReceivedTooLittleTokenOut(uint256 received, uint256 expected);
-
-  /**
    * @notice Returns the address of the Permit2 contract
    * @dev This value is constant and cannot change
    * @return The address of the Permit2 contract
@@ -81,14 +74,12 @@ abstract contract BaseCompanion is SimulationAdapter, RevokableWithGovernor, Pay
    * @param _value The value to send to the swapper as part of the swap
    * @param _swapData The swap data
    * @param _tokenOut The token that will be bought as part of the swap
-   * @param _minTokenOut The min amount of token out that we expect
    */
   function runSwap(
     address _allowanceToken,
     uint256 _value,
     bytes calldata _swapData,
-    address _tokenOut,
-    uint256 _minTokenOut
+    address _tokenOut
   ) external payable returns (uint256 _amountOut) {
     if (_allowanceToken != address(0)) {
       IERC20(_allowanceToken).forceApprove(allowanceTarget, type(uint256).max);
@@ -97,7 +88,6 @@ abstract contract BaseCompanion is SimulationAdapter, RevokableWithGovernor, Pay
     _executeSwap(swapper, _swapData, _value);
 
     _amountOut = _tokenOut == PROTOCOL_TOKEN ? address(this).balance : IERC20(_tokenOut).balanceOf(address(this));
-    if (_amountOut < _minTokenOut) revert ReceivedTooLittleTokenOut(_amountOut, _minTokenOut);
   }
 
   /**

--- a/test/integration/DCAHubCompanion/multi-call.spec.ts
+++ b/test/integration/DCAHubCompanion/multi-call.spec.ts
@@ -638,8 +638,7 @@ contract('Multicall', () => {
       constants.ZERO_ADDRESS, // No need to set it because we are already transferring the funds to the swapper
       value?.toBigInt() ?? 0,
       arbitraryCall.data,
-      tokenOut,
-      expectedAmountOut
+      tokenOut
     );
     return { swapExecutionData: data!, expectedAmountOut };
   }

--- a/test/unit/utils/base-companion.spec.ts
+++ b/test/unit/utils/base-companion.spec.ts
@@ -63,7 +63,7 @@ contract('BaseCompanion', () => {
     });
     when('swap is executed', () => {
       given(async () => {
-        await baseCompanion.runSwap(token.address, 0, swapExecution, token.address, 0);
+        await baseCompanion.runSwap(token.address, 0, swapExecution, token.address);
       });
       then('max approval is given', () => {
         expect(token.approve).to.have.been.calledOnceWith(swapper.address, constants.MaxUint256);
@@ -77,16 +77,10 @@ contract('BaseCompanion', () => {
     });
     when('allowance token is not set', () => {
       given(async () => {
-        await baseCompanion.runSwap(constants.AddressZero, 0, swapExecution, token.address, 0);
+        await baseCompanion.runSwap(constants.AddressZero, 0, swapExecution, token.address);
       });
       then('approve is not called', () => {
         expect(token.approve).to.not.have.been.called;
-      });
-    });
-    when('returned balance is less than expected', () => {
-      then('call reverts', async () => {
-        const tx = baseCompanion.runSwap(constants.AddressZero, 0, swapExecution, token.address, 1);
-        expect(tx).to.have.revertedWith('ReceivedTooLittleTokenOut(0,1)');
       });
     });
   });


### PR DESCRIPTION
Now that we've introduced [this change](https://github.com/Mean-Finance/permit2-adapter/pull/33), we can call `sellOrderSwap` and `buyOrderSwap`, that already perform this check